### PR TITLE
feat: migrate to PostgreSQL + Flyway; fix auth and serialization bugs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# character-manager-service — environment variables
+# ─────────────────────────────────────────────────────────────
+# Copy this file to .env and fill in real values.
+
+# PostgreSQL — shares the table_mimic database with auth-service.
+# The character_manage schema must exist before first startup:
+#   Run once in psql: CREATE SCHEMA IF NOT EXISTS character_manage;
+DATABASE_URL=jdbc:postgresql://localhost:5432/table_mimic
+DATABASE_USERNAME=your_db_user
+DATABASE_PASSWORD=your_db_password
+
+# Production only — override with SPRING_PROFILES_ACTIVE=prod
+# DATABASE_URL=jdbc:postgresql://<rds-host>:5432/table_mimic

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Secrets ###
+.env
+src/main/resources/application-dev.properties

--- a/pom.xml
+++ b/pom.xml
@@ -26,14 +26,13 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-database-postgresql</artifactId>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/src/main/java/com/moo/charactermanagerservice/config/AuthorizationFilter.java
+++ b/src/main/java/com/moo/charactermanagerservice/config/AuthorizationFilter.java
@@ -51,6 +51,7 @@ public class AuthorizationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        return request.getServletPath().startsWith("/health");
+        return request.getServletPath().startsWith("/health")
+            || "OPTIONS".equalsIgnoreCase(request.getMethod());
     }
 }

--- a/src/main/java/com/moo/charactermanagerservice/config/SecurityConfig.java
+++ b/src/main/java/com/moo/charactermanagerservice/config/SecurityConfig.java
@@ -29,9 +29,10 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/health/**").permitAll()
+                        .requestMatchers("/health/**", "/h2-console/**").permitAll()
                         .anyRequest().authenticated()
                 )
+                .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))
                 .addFilterBefore(authorizationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/moo/charactermanagerservice/dto/User.java
+++ b/src/main/java/com/moo/charactermanagerservice/dto/User.java
@@ -1,6 +1,6 @@
 package com.moo.charactermanagerservice.dto;
 
-import com.moo.charactermanagerservice.models.Role;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,6 +18,7 @@ import java.util.UUID;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class User implements UserDetails {
 
     private UUID uuid;
@@ -26,12 +27,13 @@ public class User implements UserDetails {
     private String lastName;
     private String email;
     private String password;
-    @Enumerated(EnumType.STRING) // Tells Spring that this is an Enum, and that we want to use it as a String, as opposed to an ordinal which will be "0, 1, 2, etc..."
-    private Role role;
+    // Auth-service returns roles as a list of strings e.g. ["USER"]
+    private List<String> roles;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority(role.name()));
+        if (roles == null || roles.isEmpty()) return List.of();
+        return roles.stream().map(SimpleGrantedAuthority::new).toList();
     }
 
     public UUID getUuid() {

--- a/src/main/java/com/moo/charactermanagerservice/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/moo/charactermanagerservice/exceptions/GlobalExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.moo.charactermanagerservice.exceptions;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.time.ZonedDateTime;
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(PCNotFoundException.class)
+    public ResponseEntity<Object> handlePCNotFound(PCNotFoundException e) {
+        return error(HttpStatus.NOT_FOUND, e.getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> handleAll(Exception e) {
+        return error(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+    }
+
+    private ResponseEntity<Object> error(HttpStatus status, String message) {
+        return ResponseEntity.status(status).body(Map.of(
+            "message", message != null ? message : "Unexpected error",
+            "httpStatus", status.name(),
+            "timeStamp", ZonedDateTime.now().toString()
+        ));
+    }
+}

--- a/src/main/java/com/moo/charactermanagerservice/models/PC.java
+++ b/src/main/java/com/moo/charactermanagerservice/models/PC.java
@@ -1,5 +1,6 @@
 package com.moo.charactermanagerservice.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -7,6 +8,7 @@ import java.io.Serializable;
 import java.util.UUID;
 
 @Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
 @Entity
 @Table(name = "pc", schema = "character_manage")
 public class PC implements Serializable {

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,20 @@
+# ── Dev profile ───────────────────────────────────────────────────────────────
+# Local PostgreSQL — same table_mimic database as auth-service, character_manage schema.
+# Copy .env.example to .env and fill in your credentials before running.
+
+spring.datasource.url=jdbc:postgresql://127.0.0.1:5434/table_mimic
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.username=table_mimic_user
+spring.datasource.password=localpassword
+
+spring.jpa.database=postgresql
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.default_schema=character_manage
+
+logging.level.org.flywaydb=INFO
+
+# Dev only — wipes and re-runs all migrations on checksum mismatch.
+# Never set this in prod: it will drop your entire schema.
+spring.flyway.clean-on-validation-error=true
+spring.flyway.clean-disabled=false

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,13 @@
+# ── Prod profile ──────────────────────────────────────────────────────────────
+# All secrets must be supplied as environment variables.
+# Activate with: SPRING_PROFILES_ACTIVE=prod
+
+spring.datasource.url=${DATABASE_URL}
+spring.datasource.driver-class-name=org.postgresql.Driver
+spring.datasource.username=${DATABASE_USERNAME}
+spring.datasource.password=${DATABASE_PASSWORD}
+
+spring.jpa.database=postgresql
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.default_schema=character_manage

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,17 +1,11 @@
-spring.datasource.username=${DATABASE_USERNAME}
-spring.datasource.password=${DATABASE_PASSWORD}
+server.port=8080
 
-spring.datasource.url=${DATABASE_URL}
-spring.datasource.driver-class-name=org.postgresql.Driver
-spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.database=postgresql
+# Active profile — override with SPRING_PROFILES_ACTIVE=prod at runtime
+spring.profiles.active=dev
 
-
-#spring.datasource.url=jdbc:h2:mem:testdb
-#spring.datasource.driverClassName=org.h2.Driver
-#spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-#spring.h2.console.enabled=true
-
-spring.jpa.properties.hibernate.hbm2ddl.auto=update
-spring.jpa.hibernate.ddl-auto=create
-spring.jpa.show-sql=true
+# Flyway — migrations in src/main/resources/db/migration
+spring.jpa.hibernate.ddl-auto=none
+spring.flyway.enabled=true
+spring.flyway.locations=classpath:db/migration
+spring.flyway.default-schema=character_manage
+spring.flyway.create-schemas=true

--- a/src/main/resources/db/migration/V1__init.sql
+++ b/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,10 @@
+CREATE SCHEMA IF NOT EXISTS character_manage;
+
+CREATE TABLE character_manage.pc (
+    id          BIGSERIAL PRIMARY KEY,
+    name        TEXT NOT NULL,
+    clazz       TEXT,
+    level       SMALLINT,
+    player_name TEXT,
+    user_id     UUID
+);


### PR DESCRIPTION
- Replace H2 with PostgreSQL (shared table_mimic DB on port 5434)
- Add Flyway migration V1__init.sql to manage character_manage schema
- Add GlobalExceptionHandler so 500 errors return readable JSON
- Fix dto.User roles field mismatch — auth service returns List<String> roles, not a singular Role enum; getNullPointerException on getAuthorities() was causing every /pc/add to 500
- Fix AuthorizationFilter blocking CORS OPTIONS preflight requests
- Add @JsonIgnoreProperties(ignoreUnknown=true) to PC and dto.User
- Fix H2 console security config (dev only)
- Add .env.example for local dev setup