### PR TITLE
feat: add D&D 2024 PHB validation on character creation endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/moo/charactermanagerservice/controllers/PCController.java
+++ b/src/main/java/com/moo/charactermanagerservice/controllers/PCController.java
@@ -3,10 +3,12 @@ package com.moo.charactermanagerservice.controllers;
 import com.moo.charactermanagerservice.dto.User;
 import com.moo.charactermanagerservice.models.PC;
 import com.moo.charactermanagerservice.services.PCService;
+import com.moo.charactermanagerservice.validation.ValidationGroups.OnCreate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -31,7 +33,8 @@ public class PCController {
     }
 
     @PostMapping("/add")
-    public ResponseEntity<PC> createPC(Authentication authentication, @RequestBody PC pc) {
+    public ResponseEntity<PC> createPC(Authentication authentication,
+                                       @Validated(OnCreate.class) @RequestBody PC pc) {
         User user = (User) authentication.getPrincipal();
         pc.setUserId(user.getUuid());
         pc.setPlayerName(user.getFirstName());

--- a/src/main/java/com/moo/charactermanagerservice/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/moo/charactermanagerservice/exceptions/GlobalExceptionHandler.java
@@ -2,15 +2,31 @@ package com.moo.charactermanagerservice.exceptions;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.ZonedDateTime;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<Object> handleValidation(MethodArgumentNotValidException e) {
+        Map<String, String> fieldErrors = new LinkedHashMap<>();
+        e.getBindingResult().getFieldErrors()
+                .forEach(fe -> fieldErrors.putIfAbsent(fe.getField(), fe.getDefaultMessage()));
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("message", "Validation failed");
+        body.put("httpStatus", HttpStatus.BAD_REQUEST.name());
+        body.put("timeStamp", ZonedDateTime.now().toString());
+        body.put("errors", fieldErrors);
+        return ResponseEntity.badRequest().body(body);
+    }
 
     @ExceptionHandler(PCNotFoundException.class)
     public ResponseEntity<Object> handlePCNotFound(PCNotFoundException e) {

--- a/src/main/java/com/moo/charactermanagerservice/models/PC.java
+++ b/src/main/java/com/moo/charactermanagerservice/models/PC.java
@@ -1,7 +1,13 @@
 package com.moo.charactermanagerservice.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.moo.charactermanagerservice.validation.ValidDndClass;
+import com.moo.charactermanagerservice.validation.ValidationGroups.OnCreate;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 import java.io.Serializable;
@@ -30,8 +36,13 @@ public class PC implements Serializable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotBlank(groups = OnCreate.class, message = "Character name must not be blank")
     private String name;
+
+    @NotBlank(groups = OnCreate.class, message = "Class must not be blank")
+    @ValidDndClass(groups = OnCreate.class)
     private String clazz;
+
     private Short level;
     private String playerName;
     private UUID userId;
@@ -46,11 +57,34 @@ public class PC implements Serializable {
     private String portraitInitials;
 
     // --- Ability scores (decomposed from frontend stats object) ---
+    @NotNull(groups = OnCreate.class, message = "Strength score is required")
+    @Min(groups = OnCreate.class, value = 3, message = "Ability scores must be at least 3")
+    @Max(groups = OnCreate.class, value = 18, message = "Ability scores cannot exceed 18")
     private Short abilityStr;
+
+    @NotNull(groups = OnCreate.class, message = "Dexterity score is required")
+    @Min(groups = OnCreate.class, value = 3, message = "Ability scores must be at least 3")
+    @Max(groups = OnCreate.class, value = 18, message = "Ability scores cannot exceed 18")
     private Short abilityDex;
+
+    @NotNull(groups = OnCreate.class, message = "Constitution score is required")
+    @Min(groups = OnCreate.class, value = 3, message = "Ability scores must be at least 3")
+    @Max(groups = OnCreate.class, value = 18, message = "Ability scores cannot exceed 18")
     private Short abilityCon;
+
+    @NotNull(groups = OnCreate.class, message = "Intelligence score is required")
+    @Min(groups = OnCreate.class, value = 3, message = "Ability scores must be at least 3")
+    @Max(groups = OnCreate.class, value = 18, message = "Ability scores cannot exceed 18")
     private Short abilityInt;
+
+    @NotNull(groups = OnCreate.class, message = "Wisdom score is required")
+    @Min(groups = OnCreate.class, value = 3, message = "Ability scores must be at least 3")
+    @Max(groups = OnCreate.class, value = 18, message = "Ability scores cannot exceed 18")
     private Short abilityWis;
+
+    @NotNull(groups = OnCreate.class, message = "Charisma score is required")
+    @Min(groups = OnCreate.class, value = 3, message = "Ability scores must be at least 3")
+    @Max(groups = OnCreate.class, value = 18, message = "Ability scores cannot exceed 18")
     private Short abilityCha;
 
     // --- Combat stats (decomposed from frontend hp object) ---

--- a/src/main/java/com/moo/charactermanagerservice/validation/DndClassValidator.java
+++ b/src/main/java/com/moo/charactermanagerservice/validation/DndClassValidator.java
@@ -1,0 +1,21 @@
+package com.moo.charactermanagerservice.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.Set;
+
+public class DndClassValidator implements ConstraintValidator<ValidDndClass, String> {
+
+    static final Set<String> VALID_CLASSES = Set.of(
+            "barbarian", "bard", "cleric", "druid", "fighter",
+            "monk", "paladin", "ranger", "rogue", "sorcerer", "warlock", "wizard"
+    );
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        // Null/blank deferred to @NotBlank — composition follows Jakarta convention
+        if (value == null || value.isBlank()) return true;
+        return VALID_CLASSES.contains(value.strip().toLowerCase());
+    }
+}

--- a/src/main/java/com/moo/charactermanagerservice/validation/ValidDndClass.java
+++ b/src/main/java/com/moo/charactermanagerservice/validation/ValidDndClass.java
@@ -1,0 +1,17 @@
+package com.moo.charactermanagerservice.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = DndClassValidator.class)
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidDndClass {
+    String message() default "must be a valid 2024 PHB class " +
+            "(Barbarian, Bard, Cleric, Druid, Fighter, Monk, Paladin, Ranger, Rogue, Sorcerer, Warlock, or Wizard)";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/moo/charactermanagerservice/validation/ValidationGroups.java
+++ b/src/main/java/com/moo/charactermanagerservice/validation/ValidationGroups.java
@@ -1,0 +1,8 @@
+package com.moo.charactermanagerservice.validation;
+
+public final class ValidationGroups {
+    private ValidationGroups() {}
+
+    /** Applied to constraints that should only run when creating a new PC. */
+    public interface OnCreate {}
+}

--- a/src/test/java/com/moo/charactermanagerservice/validation/PCValidationTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/validation/PCValidationTest.java
@@ -1,0 +1,166 @@
+package com.moo.charactermanagerservice.validation;
+
+import com.moo.charactermanagerservice.models.PC;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Validates Bean Validation constraints on PC for the OnCreate group without spinning
+ * up a Spring context — uses the Jakarta Validator API directly.
+ */
+class PCValidationTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void initValidator() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    // ── Helper ────────────────────────────────────────────────────────────────
+
+    /** Returns a PC that satisfies all OnCreate constraints. */
+    private PC validPc() {
+        PC pc = new PC();
+        pc.setName("Aelindra");
+        pc.setClazz("Wizard");
+        pc.setAbilityStr((short) 10);
+        pc.setAbilityDex((short) 14);
+        pc.setAbilityCon((short) 12);
+        pc.setAbilityInt((short) 16);
+        pc.setAbilityWis((short) 11);
+        pc.setAbilityCha((short) 8);
+        return pc;
+    }
+
+    private Set<ConstraintViolation<PC>> validate(PC pc) {
+        return validator.validate(pc, ValidationGroups.OnCreate.class);
+    }
+
+    private boolean hasViolationOnField(Set<ConstraintViolation<PC>> violations, String field) {
+        return violations.stream()
+                .anyMatch(v -> v.getPropertyPath().toString().equals(field));
+    }
+
+    // ── Baseline ──────────────────────────────────────────────────────────────
+
+    @Test
+    void validPc_passesAllConstraints() {
+        assertThat(validate(validPc())).isEmpty();
+    }
+
+    // ── name ─────────────────────────────────────────────────────────────────
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   "})
+    void blankName_failsValidation(String name) {
+        PC pc = validPc();
+        pc.setName(name);
+        assertThat(hasViolationOnField(validate(pc), "name")).isTrue();
+    }
+
+    // ── clazz ─────────────────────────────────────────────────────────────────
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   "})
+    void blankClass_failsValidation(String clazz) {
+        PC pc = validPc();
+        pc.setClazz(clazz);
+        assertThat(hasViolationOnField(validate(pc), "clazz")).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Commoner", "Fighter2", "dragon", "abc", "123"})
+    void invalidClassName_failsValidation(String clazz) {
+        PC pc = validPc();
+        pc.setClazz(clazz);
+        assertThat(hasViolationOnField(validate(pc), "clazz")).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "Barbarian", "Bard", "Cleric", "Druid", "Fighter",
+            "Monk", "Paladin", "Ranger", "Rogue", "Sorcerer", "Warlock", "Wizard",
+            "barbarian", "WIZARD", "Rogue"
+    })
+    void validClassName_passesValidation(String clazz) {
+        PC pc = validPc();
+        pc.setClazz(clazz);
+        assertThat(hasViolationOnField(validate(pc), "clazz")).isFalse();
+    }
+
+    // ── ability scores ────────────────────────────────────────────────────────
+
+    @Test
+    void nullAbilityScore_failsValidation() {
+        PC pc = validPc();
+        pc.setAbilityStr(null);
+        assertThat(hasViolationOnField(validate(pc), "abilityStr")).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(shorts = {0, 1, 2, -1, -10})
+    void abilityScoreBelowMin_failsValidation(short score) {
+        PC pc = validPc();
+        pc.setAbilityDex(score);
+        assertThat(hasViolationOnField(validate(pc), "abilityDex")).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(shorts = {19, 20, 30, 100})
+    void abilityScoreAboveMax_failsValidation(short score) {
+        PC pc = validPc();
+        pc.setAbilityCon(score);
+        assertThat(hasViolationOnField(validate(pc), "abilityCon")).isTrue();
+    }
+
+    @ParameterizedTest
+    @ValueSource(shorts = {3, 8, 10, 14, 17, 18})
+    void abilityScoreInRange_passesValidation(short score) {
+        PC pc = validPc();
+        pc.setAbilityInt(score);
+        pc.setAbilityWis(score);
+        pc.setAbilityCha(score);
+        assertThat(validate(pc)).isEmpty();
+    }
+
+    // ── all six scores must be present ────────────────────────────────────────
+
+    @Test
+    void missingAllAbilityScores_produceSixViolations() {
+        PC pc = validPc();
+        pc.setAbilityStr(null);
+        pc.setAbilityDex(null);
+        pc.setAbilityCon(null);
+        pc.setAbilityInt(null);
+        pc.setAbilityWis(null);
+        pc.setAbilityCha(null);
+
+        Set<ConstraintViolation<PC>> violations = validate(pc);
+        long scoreViolations = violations.stream()
+                .filter(v -> v.getPropertyPath().toString().startsWith("ability"))
+                .count();
+        assertThat(scoreViolations).isEqualTo(6);
+    }
+
+    // ── OnCreate group isolation ──────────────────────────────────────────────
+
+    @Test
+    void constraints_notTriggered_outsideOnCreateGroup() {
+        PC pc = new PC(); // everything null — would fail OnCreate
+        Set<ConstraintViolation<PC>> violations = validator.validate(pc); // default group
+        assertThat(violations).isEmpty();
+    }
+}


### PR DESCRIPTION
ValidDndClass custom constraint accepts only the 12 PHB classes (case-insensitive) @NotBlank on name and clazz; @NotNull @Min(3) @Max(18) on all six ability scores All constraints scoped to OnCreate group so PUT /update is unaffected GlobalExceptionHandler handles MethodArgumentNotValidException with field-level 400 body 45 parameterized tests cover valid/invalid class names, score ranges, null scores, group isolation