### PR TITLE
feat: make character-manager deploy-ready for AWS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,10 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>

--- a/src/main/java/com/moo/charactermanagerservice/config/AuthorizationFilter.java
+++ b/src/main/java/com/moo/charactermanagerservice/config/AuthorizationFilter.java
@@ -52,6 +52,7 @@ public class AuthorizationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         return request.getServletPath().startsWith("/health")
+            || request.getServletPath().startsWith("/actuator")
             || "OPTIONS".equalsIgnoreCase(request.getMethod());
     }
 }

--- a/src/main/java/com/moo/charactermanagerservice/config/SecurityConfig.java
+++ b/src/main/java/com/moo/charactermanagerservice/config/SecurityConfig.java
@@ -10,13 +10,20 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.beans.factory.annotation.Value;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Configuration
 public class SecurityConfig {
 
     private final AuthorizationFilter authorizationFilter;
+
+    // Comma-separated allowed SPA origins. Supplied in prod via CORS_ALLOWED_ORIGINS
+    // (set by Terraform to the frontend CloudFront domain); defaults to local dev.
+    @Value("${cors.allowed-origins:http://localhost:4200}")
+    private String corsAllowedOrigins;
 
     public SecurityConfig(AuthorizationFilter authorizationFilter) {
         this.authorizationFilter = authorizationFilter;
@@ -29,7 +36,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/health/**", "/h2-console/**").permitAll()
+                        .requestMatchers("/health/**", "/actuator/health", "/h2-console/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))
@@ -41,7 +48,10 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:4200"));
+        config.setAllowedOrigins(Arrays.stream(corsAllowedOrigins.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList());
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         config.setAllowedHeaders(List.of("Authorization", "Content-Type"));
         config.setAllowCredentials(true);

--- a/src/main/java/com/moo/charactermanagerservice/services/UserService.java
+++ b/src/main/java/com/moo/charactermanagerservice/services/UserService.java
@@ -1,6 +1,7 @@
 package com.moo.charactermanagerservice.services;
 
 import com.moo.charactermanagerservice.dto.User;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,11 @@ public class UserService {
 
     private final RestTemplate restTemplate;
 
+    // Base URL of the authentication-service. In prod this is the auth App Runner URL,
+    // supplied via the AUTH_SERVICE_URL env var (set by Terraform); defaults to local dev.
+    @Value("${auth.service.url:http://localhost:8085}")
+    private String authServiceUrl;
+
     public UserService() {
         this.restTemplate = new RestTemplate();
     }
@@ -29,7 +35,7 @@ public class UserService {
             HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
 
             ResponseEntity<User> response = restTemplate.exchange(
-                    "http://localhost:8085/api/v1/auth/authorize", HttpMethod.GET, requestEntity, User.class
+                    authServiceUrl + "/api/v1/auth/authorize", HttpMethod.GET, requestEntity, User.class
             );
 
             return response.getBody();

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,5 +1,5 @@
 # ── Dev profile ───────────────────────────────────────────────────────────────
-# Local PostgreSQL — same table_mimic database as auth-service, character_manage schema.
+# Local PostgreSQL — same table_mimic database as auth-service, `character` schema.
 # Copy .env.example to .env and fill in your credentials before running.
 
 spring.datasource.url=jdbc:postgresql://127.0.0.1:5434/table_mimic
@@ -10,7 +10,7 @@ spring.datasource.password=localpassword
 spring.jpa.database=postgresql
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.default_schema=character_manage
+spring.jpa.properties.hibernate.default_schema=character
 
 logging.level.org.flywaydb=INFO
 

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -10,4 +10,14 @@ spring.datasource.password=${DATABASE_PASSWORD}
 spring.jpa.database=postgresql
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.show-sql=false
-spring.jpa.properties.hibernate.default_schema=character_manage
+spring.jpa.properties.hibernate.default_schema=character
+
+# No Flyway migrations exist for this service; Hibernate manages the schema (same
+# approach as authentication-service). The tm_prod_character role owns the `character`
+# schema, so it can create its own tables.
+spring.jpa.hibernate.ddl-auto=update
+spring.flyway.enabled=false
+
+# Actuator — expose only the health endpoint for the App Runner health check.
+management.endpoints.web.exposure.include=health
+management.endpoint.health.probes.enabled=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,5 +7,5 @@ spring.profiles.active=dev
 spring.jpa.hibernate.ddl-auto=none
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
-spring.flyway.default-schema=character_manage
+spring.flyway.default-schema=character
 spring.flyway.create-schemas=true


### PR DESCRIPTION
- Add spring-boot-starter-actuator; expose /actuator/health for the App Runner health check and permit it unauthenticated in security config + auth filter.
- Externalize the auth-service base URL to AUTH_SERVICE_URL (was hard-coded to http://localhost:8085, which can't reach auth-service across App Runner hosts).
- Externalize CORS origins to CORS_ALLOWED_ORIGINS (was hard-coded localhost:4200).
- Standardize the schema name character_manage -> character (CONVENTIONS 3.4, matches the DB topology + JDBC currentSchema).
- Prod: ddl-auto=update + Flyway disabled (no migration scripts exist), matching authentication-service so Hibernate creates the pc table in the character schema.