### PR TITLE
fix: don't let Flyway create the schema in prod (least-privilege role)

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -15,6 +15,11 @@ spring.jpa.properties.hibernate.default_schema=character
 # Schema is owned by Flyway (db/migration), which runs in the `character` schema
 # owned by the tm_<env>_character role. Hibernate does not touch the schema
 # (ddl-auto=none, inherited from application.properties).
+#
+# That role has no CREATE on the database (least privilege), so Flyway must NOT try
+# to create the schema (the DB bootstrap already created it). Local dev keeps
+# create-schemas=true (base config) where the role can create schemas.
+spring.flyway.create-schemas=false
 
 # Actuator — expose only the health endpoint for the App Runner health check.
 management.endpoints.web.exposure.include=health


### PR DESCRIPTION
The tm_<env>_character role owns its schema but has no CREATE on the database, so Flyway create-schemas=true (base) would fail with 'permission denied for database' exactly like auth-service. The DB bootstrap pre-creates the schema, so set spring.flyway.create-schemas=false in prod (local dev keeps base true).