### PR TITLE
feat: add server-authoritative character level-up (HP + proficiency b…

### DIFF
--- a/src/main/java/com/moo/charactermanagerservice/controllers/PCController.java
+++ b/src/main/java/com/moo/charactermanagerservice/controllers/PCController.java
@@ -1,5 +1,6 @@
 package com.moo.charactermanagerservice.controllers;
 
+import com.moo.charactermanagerservice.dto.LevelUpPreview;
 import com.moo.charactermanagerservice.dto.User;
 import com.moo.charactermanagerservice.models.PC;
 import com.moo.charactermanagerservice.services.PCService;
@@ -47,6 +48,18 @@ public class PCController {
         User user = (User) authentication.getPrincipal();
         pc.setId(id);
         return ResponseEntity.ok(pcService.updatePC(pc, user.getUuid()));
+    }
+
+    @GetMapping("/{id}/level-up/preview")
+    public ResponseEntity<LevelUpPreview> previewLevelUp(@PathVariable Long id, Authentication authentication) {
+        User user = (User) authentication.getPrincipal();
+        return ResponseEntity.ok(pcService.previewLevelUp(id, user.getUuid()));
+    }
+
+    @PostMapping("/{id}/level-up")
+    public ResponseEntity<PC> levelUp(@PathVariable Long id, Authentication authentication) {
+        User user = (User) authentication.getPrincipal();
+        return ResponseEntity.ok(pcService.levelUpPC(id, user.getUuid()));
     }
 
     @DeleteMapping("/delete/{id}")

--- a/src/main/java/com/moo/charactermanagerservice/dto/LevelUpPreview.java
+++ b/src/main/java/com/moo/charactermanagerservice/dto/LevelUpPreview.java
@@ -1,0 +1,18 @@
+package com.moo.charactermanagerservice.dto;
+
+/**
+ * Read-only projection of what advancing one level would grant, computed server-side so the
+ * SPA can render the deltas before the user commits. No persistence and no player choices —
+ * Phase 1 covers the deterministic gains (HP via fixed average, proficiency bonus). Later
+ * phases that introduce choices (subclass, ASI/feat, spells) add a separate request contract.
+ */
+public record LevelUpPreview(
+        int currentLevel,
+        int newLevel,
+        int hitDie,
+        int conModifier,
+        int hpGained,
+        int newHpMax,
+        int currentProfBonus,
+        int newProfBonus
+) {}

--- a/src/main/java/com/moo/charactermanagerservice/progression/ClassProgression.java
+++ b/src/main/java/com/moo/charactermanagerservice/progression/ClassProgression.java
@@ -1,0 +1,74 @@
+package com.moo.charactermanagerservice.progression;
+
+import java.util.Map;
+
+/**
+ * Static D&D 5e (2024) single-class progression rules.
+ *
+ * <p>This is the server-authoritative source of truth for level-dependent math. The SPA
+ * renders the results of these functions; it never recomputes them. Tables live here — in
+ * their own package — rather than inside {@code PCService}, which keeps persistence/ownership
+ * (PCService) separate from the rules engine (this + {@link com.moo.charactermanagerservice.services.LevelUpService}).
+ *
+ * <p>Pure functions and immutable tables only: no Spring, no I/O, no entity dependency, so it
+ * is trivially unit-testable. As later phases land, spell-slot / subclass-level / ASI / feature
+ * tables join this class (or sibling classes in this package).
+ */
+public final class ClassProgression {
+
+    private ClassProgression() {}
+
+    /** Highest single-class level supported by 5e. */
+    public static final int MAX_LEVEL = 20;
+
+    /** Hit die used when a class is unknown/unmapped. */
+    public static final int DEFAULT_HIT_DIE = 8;
+
+    /**
+     * Hit die size per class (2024 PHB). Keyed lower-case; lookups normalise case so the
+     * persisted {@code clazz} ("Wizard") and any future input shape both resolve.
+     */
+    private static final Map<String, Integer> HIT_DICE = Map.ofEntries(
+            Map.entry("barbarian", 12),
+            Map.entry("fighter", 10),
+            Map.entry("paladin", 10),
+            Map.entry("ranger", 10),
+            Map.entry("bard", 8),
+            Map.entry("cleric", 8),
+            Map.entry("druid", 8),
+            Map.entry("monk", 8),
+            Map.entry("rogue", 8),
+            Map.entry("warlock", 8),
+            Map.entry("sorcerer", 6),
+            Map.entry("wizard", 6)
+    );
+
+    /** Hit die for a class; case-insensitive, defaults to {@value #DEFAULT_HIT_DIE} for unknowns. */
+    public static int hitDie(String clazz) {
+        if (clazz == null) {
+            return DEFAULT_HIT_DIE;
+        }
+        return HIT_DICE.getOrDefault(clazz.trim().toLowerCase(), DEFAULT_HIT_DIE);
+    }
+
+    /**
+     * Fixed-average value taken from one hit die on level-up: {@code die/2 + 1}
+     * (d6=4, d8=5, d10=6, d12=7). Rolled HP is a future seam handled at the call site.
+     */
+    public static int averageHitDieValue(int hitDie) {
+        return hitDie / 2 + 1;
+    }
+
+    /**
+     * Proficiency bonus for a total character level: {@code (level-1)/4 + 2}.
+     * Bumps at levels 5, 9, 13, 17. Keyed on total level so it is already multiclass-correct.
+     */
+    public static int proficiencyBonusForLevel(int level) {
+        return (level - 1) / 4 + 2;
+    }
+
+    /** Ability modifier, floored so low/odd scores resolve correctly (e.g. 3 -> -4, 9 -> -1). */
+    public static int abilityModifier(int score) {
+        return Math.floorDiv(score - 10, 2);
+    }
+}

--- a/src/main/java/com/moo/charactermanagerservice/services/LevelUpService.java
+++ b/src/main/java/com/moo/charactermanagerservice/services/LevelUpService.java
@@ -1,0 +1,94 @@
+package com.moo.charactermanagerservice.services;
+
+import com.moo.charactermanagerservice.dto.LevelUpPreview;
+import com.moo.charactermanagerservice.models.PC;
+import com.moo.charactermanagerservice.progression.ClassProgression;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+/**
+ * Server-authoritative level-up rules engine (single-class, D&D 5e 2024).
+ *
+ * <p><strong>Single responsibility:</strong> compute the deterministic gains of advancing one
+ * level. It does not load, persist, or authorize — {@link PCService} owns that and delegates
+ * here. Keeping the rules out of the controller and out of PCService means the math is unit
+ * tested in isolation (no repo, no Spring context, no security).
+ *
+ * <p><strong>HP policy (Phase 1):</strong> fixed average — {@code averageHitDieValue + CON mod},
+ * floored at {@value #MIN_HP_PER_LEVEL} per level (5e minimum). Rolled HP is a future seam: it
+ * would swap the {@link #hpGain} strategy without touching callers.
+ *
+ * <p><strong>Multiclass seam:</strong> today total level == single class level, so hit die keys
+ * off {@code pc.clazz} and proficiency bonus off {@code pc.level}. When multiclassing lands,
+ * hit-die/feature lookups move to {@code (class, classLevel)} while proficiency bonus stays on
+ * total level — only the inputs change, not this contract.
+ */
+@Service
+public class LevelUpService {
+
+    /** A character always gains at least this much HP per level, even with a CON penalty. */
+    private static final int MIN_HP_PER_LEVEL = 1;
+
+    /** Compute — without persisting — what advancing one level would grant. */
+    public LevelUpPreview preview(PC pc) {
+        int currentLevel = currentLevel(pc);
+        assertCanLevelUp(currentLevel);
+
+        int newLevel = currentLevel + 1;
+        int hitDie = ClassProgression.hitDie(pc.getClazz());
+        int conMod = ClassProgression.abilityModifier(nz(pc.getAbilityCon()));
+        int hpGained = hpGain(hitDie, conMod);
+
+        return new LevelUpPreview(
+                currentLevel,
+                newLevel,
+                hitDie,
+                conMod,
+                hpGained,
+                nz(pc.getHpMax()) + hpGained,
+                ClassProgression.proficiencyBonusForLevel(currentLevel),
+                ClassProgression.proficiencyBonusForLevel(newLevel)
+        );
+    }
+
+    /**
+     * Mutate the given (managed) PC in place to its next level: bump level, add the HP gain to
+     * both max and current HP, and recompute the proficiency bonus. The caller persists.
+     */
+    public PC applyLevelUp(PC pc) {
+        int currentLevel = currentLevel(pc);
+        assertCanLevelUp(currentLevel);
+
+        int newLevel = currentLevel + 1;
+        int hitDie = ClassProgression.hitDie(pc.getClazz());
+        int conMod = ClassProgression.abilityModifier(nz(pc.getAbilityCon()));
+        int hpGained = hpGain(hitDie, conMod);
+
+        pc.setLevel((short) newLevel);
+        pc.setHpMax((short) (nz(pc.getHpMax()) + hpGained));
+        pc.setHpCurrent((short) (nz(pc.getHpCurrent()) + hpGained));
+        pc.setProfBonus((short) ClassProgression.proficiencyBonusForLevel(newLevel));
+        return pc;
+    }
+
+    private int hpGain(int hitDie, int conMod) {
+        return Math.max(MIN_HP_PER_LEVEL, ClassProgression.averageHitDieValue(hitDie) + conMod);
+    }
+
+    private int currentLevel(PC pc) {
+        return pc.getLevel() == null ? 1 : pc.getLevel();
+    }
+
+    private void assertCanLevelUp(int currentLevel) {
+        if (currentLevel >= ClassProgression.MAX_LEVEL) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Character is already at the maximum level (" + ClassProgression.MAX_LEVEL + ")");
+        }
+    }
+
+    /** Null-safe read of a nullable Short stat as a primitive (older PCs may have null combat stats). */
+    private static int nz(Short value) {
+        return value == null ? 0 : value;
+    }
+}

--- a/src/main/java/com/moo/charactermanagerservice/services/PCService.java
+++ b/src/main/java/com/moo/charactermanagerservice/services/PCService.java
@@ -1,11 +1,13 @@
 package com.moo.charactermanagerservice.services;
 
+import com.moo.charactermanagerservice.dto.LevelUpPreview;
 import com.moo.charactermanagerservice.exceptions.PCNotFoundException;
 import com.moo.charactermanagerservice.models.PC;
 import com.moo.charactermanagerservice.repositories.PCRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
@@ -15,10 +17,12 @@ import java.util.UUID;
 public class PCService {
 
     private final PCRepository pcRepository;
+    private final LevelUpService levelUpService;
 
     @Autowired
-    public PCService(PCRepository pcRepository) {
+    public PCService(PCRepository pcRepository, LevelUpService levelUpService) {
         this.pcRepository = pcRepository;
+        this.levelUpService = levelUpService;
     }
 
     public PC addPC(PC pc) {
@@ -44,6 +48,27 @@ public class PCService {
     public PC updatePC(PC pc, UUID userId) {
         PC existing = findPCById(pc.getId());
         assertOwnership(existing, userId);
+        return pcRepository.save(pc);
+    }
+
+    /**
+     * Compute, without persisting, the gains of advancing this PC one level. Enforces ownership.
+     * Drives the SPA's pre-confirmation preview so the client never computes D&D rules itself.
+     */
+    public LevelUpPreview previewLevelUp(Long id, UUID userId) {
+        PC pc = findPCByIdForUser(id, userId);
+        return levelUpService.preview(pc);
+    }
+
+    /**
+     * Advance this PC one level and persist. Ownership is enforced and the rules are applied
+     * server-side ({@link LevelUpService}); the client supplies no stats. {@code @Transactional}
+     * keeps the load-modify-save atomic so a level can't be applied twice from a single request.
+     */
+    @Transactional
+    public PC levelUpPC(Long id, UUID userId) {
+        PC pc = findPCByIdForUser(id, userId);
+        levelUpService.applyLevelUp(pc);
         return pcRepository.save(pc);
     }
 

--- a/src/test/java/com/moo/charactermanagerservice/controllers/PCControllerTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/controllers/PCControllerTest.java
@@ -1,5 +1,6 @@
 package com.moo.charactermanagerservice.controllers;
 
+import com.moo.charactermanagerservice.dto.LevelUpPreview;
 import com.moo.charactermanagerservice.dto.User;
 import com.moo.charactermanagerservice.exceptions.PCNotFoundException;
 import com.moo.charactermanagerservice.models.PC;
@@ -164,6 +165,61 @@ class PCControllerTest {
         assertThatThrownBy(() -> pcController.updatePC(1L, auth, pc))
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(403));
+    }
+
+    // --- GET /{id}/level-up/preview ---
+
+    @Test
+    void previewLevelUp_returns200_withPreview() {
+        LevelUpPreview preview = new LevelUpPreview(4, 5, 10, 3, 9, 39, 2, 3);
+        when(pcService.previewLevelUp(1L, ownerId)).thenReturn(preview);
+
+        ResponseEntity<LevelUpPreview> response = pcController.previewLevelUp(1L, auth);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isSameAs(preview);
+    }
+
+    @Test
+    void previewLevelUp_propagates403_whenNotOwner() {
+        when(pcService.previewLevelUp(1L, ownerId))
+                .thenThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied"));
+
+        assertThatThrownBy(() -> pcController.previewLevelUp(1L, auth))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(403));
+    }
+
+    // --- POST /{id}/level-up ---
+
+    @Test
+    void levelUp_returns200_whenOwner() {
+        when(pcService.levelUpPC(1L, ownerId)).thenReturn(pc);
+
+        ResponseEntity<PC> response = pcController.levelUp(1L, auth);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isSameAs(pc);
+    }
+
+    @Test
+    void levelUp_propagates403_whenNotOwner() {
+        when(pcService.levelUpPC(1L, ownerId))
+                .thenThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied"));
+
+        assertThatThrownBy(() -> pcController.levelUp(1L, auth))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(403));
+    }
+
+    @Test
+    void levelUp_propagates409_whenAtMaxLevel() {
+        when(pcService.levelUpPC(1L, ownerId))
+                .thenThrow(new ResponseStatusException(HttpStatus.CONFLICT, "Character is already at the maximum level (20)"));
+
+        assertThatThrownBy(() -> pcController.levelUp(1L, auth))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(409));
     }
 
     // --- DELETE /delete/{id} ---

--- a/src/test/java/com/moo/charactermanagerservice/services/LevelUpServiceTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/services/LevelUpServiceTest.java
@@ -1,0 +1,145 @@
+package com.moo.charactermanagerservice.services;
+
+import com.moo.charactermanagerservice.dto.LevelUpPreview;
+import com.moo.charactermanagerservice.models.PC;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pure unit tests for the level-up rules engine — no repo, no Spring, no security.
+ * Covers the deterministic Phase 1 gains: fixed-average HP (hit-die avg + CON mod, floored at 1)
+ * and the proficiency-bonus bumps at levels 5/9/13/17.
+ */
+class LevelUpServiceTest {
+
+    private final LevelUpService service = new LevelUpService();
+
+    /** Build a minimal PC with the stats Phase 1 touches. */
+    private static PC pc(String clazz, int level, int con, int hpMax, int hpCurrent) {
+        PC pc = new PC();
+        pc.setClazz(clazz);
+        pc.setLevel((short) level);
+        pc.setAbilityCon((short) con);
+        pc.setHpMax((short) hpMax);
+        pc.setHpCurrent((short) hpCurrent);
+        return pc;
+    }
+
+    // --- proficiency bonus progression ---
+
+    @Test
+    void profBonus_bumpsAtThresholds() {
+        // newLevel -> expected prof bonus
+        assertThat(service.preview(pc("Wizard", 1, 10, 6, 6)).newProfBonus()).isEqualTo(2);  // ->2
+        assertThat(service.preview(pc("Wizard", 4, 10, 6, 6)).newProfBonus()).isEqualTo(3);  // ->5
+        assertThat(service.preview(pc("Wizard", 8, 10, 6, 6)).newProfBonus()).isEqualTo(4);  // ->9
+        assertThat(service.preview(pc("Wizard", 12, 10, 6, 6)).newProfBonus()).isEqualTo(5); // ->13
+        assertThat(service.preview(pc("Wizard", 16, 10, 6, 6)).newProfBonus()).isEqualTo(6); // ->17
+    }
+
+    @Test
+    void profBonus_unchangedWithinBand() {
+        LevelUpPreview p = service.preview(pc("Fighter", 1, 10, 12, 12)); // 1 -> 2, both band 2
+        assertThat(p.currentProfBonus()).isEqualTo(2);
+        assertThat(p.newProfBonus()).isEqualTo(2);
+    }
+
+    // --- HP gain (fixed average + CON mod) per hit die ---
+
+    @Test
+    void hpGain_wizardD6() {
+        // d6 avg = 4, CON 14 (+2) -> 6
+        assertThat(service.preview(pc("Wizard", 1, 14, 8, 8)).hpGained()).isEqualTo(6);
+    }
+
+    @Test
+    void hpGain_fighterD10() {
+        // d10 avg = 6, CON 16 (+3) -> 9
+        assertThat(service.preview(pc("Fighter", 1, 16, 12, 12)).hpGained()).isEqualTo(9);
+    }
+
+    @Test
+    void hpGain_barbarianD12() {
+        // d12 avg = 7, CON 12 (+1) -> 8
+        assertThat(service.preview(pc("Barbarian", 1, 12, 15, 15)).hpGained()).isEqualTo(8);
+    }
+
+    @Test
+    void hpGain_unknownClassDefaultsToD8() {
+        // default d8 avg = 5, CON 10 (+0) -> 5
+        assertThat(service.preview(pc("Artificer", 1, 10, 8, 8)).hpGained()).isEqualTo(5);
+    }
+
+    @Test
+    void hpGain_flooredAtOne_withHeavyConPenalty() {
+        // d6 avg = 4, CON 3 (-4) -> 0, floored to 1
+        assertThat(service.preview(pc("Sorcerer", 1, 3, 4, 4)).hpGained()).isEqualTo(1);
+    }
+
+    @Test
+    void hpGain_nullConTreatedAsZeroScore() {
+        PC pc = pc("Wizard", 1, 10, 8, 8);
+        pc.setAbilityCon(null);
+        // CON null -> score 0 -> mod floor((0-10)/2) = -5; d6 avg 4 - 5 = -1 -> floored to 1
+        assertThat(service.preview(pc).hpGained()).isEqualTo(1);
+    }
+
+    // --- applyLevelUp mutates the entity ---
+
+    @Test
+    void applyLevelUp_mutatesLevelHpAndProf() {
+        PC pc = pc("Fighter", 4, 16, 30, 22); // ->5: prof 2->3, HP +9
+        service.applyLevelUp(pc);
+
+        assertThat(pc.getLevel()).isEqualTo((short) 5);
+        assertThat(pc.getHpMax()).isEqualTo((short) 39);
+        assertThat(pc.getHpCurrent()).isEqualTo((short) 31);
+        assertThat(pc.getProfBonus()).isEqualTo((short) 3);
+    }
+
+    @Test
+    void preview_doesNotMutate() {
+        PC pc = pc("Fighter", 4, 16, 30, 22);
+        service.preview(pc);
+
+        assertThat(pc.getLevel()).isEqualTo((short) 4);
+        assertThat(pc.getHpMax()).isEqualTo((short) 30);
+        assertThat(pc.getProfBonus()).isNull();
+    }
+
+    @Test
+    void preview_reportsCurrentAndNewLevel() {
+        LevelUpPreview p = service.preview(pc("Cleric", 7, 14, 50, 50));
+        assertThat(p.currentLevel()).isEqualTo(7);
+        assertThat(p.newLevel()).isEqualTo(8);
+        assertThat(p.newHpMax()).isEqualTo(50 + p.hpGained());
+    }
+
+    @Test
+    void nullLevel_treatedAsLevelOne() {
+        PC pc = pc("Wizard", 1, 10, 6, 6);
+        pc.setLevel(null);
+        assertThat(service.preview(pc).newLevel()).isEqualTo(2);
+    }
+
+    // --- max-level guard ---
+
+    @Test
+    void applyLevelUp_throws409_atMaxLevel() {
+        PC pc = pc("Wizard", 20, 14, 200, 200);
+        assertThatThrownBy(() -> service.applyLevelUp(pc))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(409));
+    }
+
+    @Test
+    void preview_throws409_atMaxLevel() {
+        PC pc = pc("Wizard", 20, 14, 200, 200);
+        assertThatThrownBy(() -> service.preview(pc))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(409));
+    }
+}

--- a/src/test/java/com/moo/charactermanagerservice/services/PCServiceTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/services/PCServiceTest.java
@@ -1,5 +1,6 @@
 package com.moo.charactermanagerservice.services;
 
+import com.moo.charactermanagerservice.dto.LevelUpPreview;
 import com.moo.charactermanagerservice.exceptions.PCNotFoundException;
 import com.moo.charactermanagerservice.models.PC;
 import com.moo.charactermanagerservice.repositories.PCRepository;
@@ -24,6 +25,9 @@ class PCServiceTest {
 
     @Mock
     private PCRepository pcRepository;
+
+    @Mock
+    private LevelUpService levelUpService;
 
     @InjectMocks
     private PCService pcService;
@@ -129,6 +133,58 @@ class PCServiceTest {
                         .isEqualTo(403));
 
         verify(pcRepository, never()).save(any());
+    }
+
+    // --- levelUpPC ---
+
+    @Test
+    void levelUpPC_appliesRulesAndSaves_whenOwner() {
+        when(pcRepository.findById(1L)).thenReturn(Optional.of(pc));
+        when(pcRepository.save(pc)).thenReturn(pc);
+
+        PC result = pcService.levelUpPC(1L, ownerId);
+
+        assertThat(result).isSameAs(pc);
+        verify(levelUpService).applyLevelUp(pc);
+        verify(pcRepository).save(pc);
+    }
+
+    @Test
+    void levelUpPC_throws403_whenNotOwner() {
+        when(pcRepository.findById(1L)).thenReturn(Optional.of(pc));
+
+        assertThatThrownBy(() -> pcService.levelUpPC(1L, strangerId))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value())
+                        .isEqualTo(403));
+
+        verify(levelUpService, never()).applyLevelUp(any());
+        verify(pcRepository, never()).save(any());
+    }
+
+    // --- previewLevelUp ---
+
+    @Test
+    void previewLevelUp_returnsPreview_whenOwner() {
+        LevelUpPreview preview = new LevelUpPreview(4, 5, 8, 2, 7, 39, 2, 3);
+        when(pcRepository.findById(1L)).thenReturn(Optional.of(pc));
+        when(levelUpService.preview(pc)).thenReturn(preview);
+
+        LevelUpPreview result = pcService.previewLevelUp(1L, ownerId);
+
+        assertThat(result).isSameAs(preview);
+    }
+
+    @Test
+    void previewLevelUp_throws403_whenNotOwner() {
+        when(pcRepository.findById(1L)).thenReturn(Optional.of(pc));
+
+        assertThatThrownBy(() -> pcService.previewLevelUp(1L, strangerId))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value())
+                        .isEqualTo(403));
+
+        verify(levelUpService, never()).preview(any());
     }
 
     // --- deletePC ---


### PR DESCRIPTION
…onus)

Phase 1 of the level-up feature. The D&D 5e (2024) rules engine lives in the service tier, not the SPA: a new ClassProgression table + LevelUpService compute the deterministic single-level gains (fixed-average HP = hit-die avg + CON mod, floored at 1; proficiency bonus by total level). PCService owns ownership and persistence and delegates the math.

New endpoints (ownership enforced, 409 at max level):
- GET  /api/v1/pc/{id}/level-up/preview  -> LevelUpPreview (no mutation)
- POST /api/v1/pc/{id}/level-up          -> persisted updated PC (@Transactional)

Tests: LevelUpServiceTest (prof bumps 5/9/13/17, per-die HP, CON mod, min-1 floor, max-level guard) plus PCService/PCController additions. 114 tests green.

Multiclass and rolled-HP seams left in LevelUpService; later phases extend ClassProgression with slot/subclass/ASI/feature tables.