### PR TITLE
feat: add spell-slot progression to level-up (Phase 2)

### DIFF
--- a/src/main/java/com/moo/charactermanagerservice/dto/LevelUpPreview.java
+++ b/src/main/java/com/moo/charactermanagerservice/dto/LevelUpPreview.java
@@ -1,10 +1,15 @@
 package com.moo.charactermanagerservice.dto;
 
+import java.util.Map;
+
 /**
  * Read-only projection of what advancing one level would grant, computed server-side so the
- * SPA can render the deltas before the user commits. No persistence and no player choices —
- * Phase 1 covers the deterministic gains (HP via fixed average, proficiency bonus). Later
- * phases that introduce choices (subclass, ASI/feat, spells) add a separate request contract.
+ * SPA can render the deltas before the user commits. No persistence and no player choices.
+ *
+ * <p>Phase 1: deterministic gains (HP via fixed average, proficiency bonus). Phase 2 adds the
+ * spell-slot picture — {@code spellLevel -> maxSlots} before and after the level — which is
+ * empty for non-casters. Later phases that introduce choices (subclass, ASI/feat, spells) add
+ * a separate request contract.
  */
 public record LevelUpPreview(
         int currentLevel,
@@ -14,5 +19,7 @@ public record LevelUpPreview(
         int hpGained,
         int newHpMax,
         int currentProfBonus,
-        int newProfBonus
+        int newProfBonus,
+        Map<Integer, Integer> currentSpellSlots,
+        Map<Integer, Integer> newSpellSlots
 ) {}

--- a/src/main/java/com/moo/charactermanagerservice/progression/ClassProgression.java
+++ b/src/main/java/com/moo/charactermanagerservice/progression/ClassProgression.java
@@ -1,6 +1,8 @@
 package com.moo.charactermanagerservice.progression;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Static D&D 5e (2024) single-class progression rules.
@@ -70,5 +72,100 @@ public final class ClassProgression {
     /** Ability modifier, floored so low/odd scores resolve correctly (e.g. 3 -> -4, 9 -> -1). */
     public static int abilityModifier(int score) {
         return Math.floorDiv(score - 10, 2);
+    }
+
+    // ── Spell-slot progression (Phase 2) ────────────────────────────────────────
+    // Caster set intentionally matches what the app already models as spellcasters
+    // (frontend SPELLCASTING_CLASSES + the create wizard's starting slots): five full
+    // casters plus warlock pact magic. Paladin/Ranger are NOT included — the app does
+    // not represent them as casters, and consistency with the existing data model wins
+    // over 2024-PHB half-caster rules. Add them here (and in the app) when that changes.
+
+    private static final Set<String> FULL_CASTERS =
+            Set.of("bard", "cleric", "druid", "sorcerer", "wizard");
+
+    /** Warlock — pact magic: a single slot level with a small number of short-rest slots. */
+    public static final String PACT_CASTER = "warlock";
+
+    /**
+     * Full-caster slots by character level (rows, 1-indexed via {@code level-1}) and spell
+     * level (columns, spell levels 1-9). Standard 5e full-caster table; zeros = no slots.
+     */
+    private static final int[][] FULL_CASTER_SLOTS = {
+            //  1  2  3  4  5  6  7  8  9   <- spell level
+            {  2, 0, 0, 0, 0, 0, 0, 0, 0 }, // L1
+            {  3, 0, 0, 0, 0, 0, 0, 0, 0 }, // L2
+            {  4, 2, 0, 0, 0, 0, 0, 0, 0 }, // L3
+            {  4, 3, 0, 0, 0, 0, 0, 0, 0 }, // L4
+            {  4, 3, 2, 0, 0, 0, 0, 0, 0 }, // L5
+            {  4, 3, 3, 0, 0, 0, 0, 0, 0 }, // L6
+            {  4, 3, 3, 1, 0, 0, 0, 0, 0 }, // L7
+            {  4, 3, 3, 2, 0, 0, 0, 0, 0 }, // L8
+            {  4, 3, 3, 3, 1, 0, 0, 0, 0 }, // L9
+            {  4, 3, 3, 3, 2, 0, 0, 0, 0 }, // L10
+            {  4, 3, 3, 3, 2, 1, 0, 0, 0 }, // L11
+            {  4, 3, 3, 3, 2, 1, 0, 0, 0 }, // L12
+            {  4, 3, 3, 3, 2, 1, 1, 0, 0 }, // L13
+            {  4, 3, 3, 3, 2, 1, 1, 0, 0 }, // L14
+            {  4, 3, 3, 3, 2, 1, 1, 1, 0 }, // L15
+            {  4, 3, 3, 3, 2, 1, 1, 1, 0 }, // L16
+            {  4, 3, 3, 3, 2, 1, 1, 1, 1 }, // L17
+            {  4, 3, 3, 3, 3, 1, 1, 1, 1 }, // L18
+            {  4, 3, 3, 3, 3, 2, 1, 1, 1 }, // L19
+            {  4, 3, 3, 3, 3, 2, 2, 1, 1 }, // L20
+    };
+
+    /** Warlock pact slots by character level: {@code {pactSlotLevel, slotCount}}. */
+    private static final int[][] PACT_SLOTS = {
+            { 1, 1 }, // L1
+            { 1, 2 }, // L2
+            { 2, 2 }, // L3
+            { 2, 2 }, // L4
+            { 3, 2 }, // L5
+            { 3, 2 }, // L6
+            { 4, 2 }, // L7
+            { 4, 2 }, // L8
+            { 5, 2 }, // L9
+            { 5, 2 }, // L10
+            { 5, 3 }, // L11
+            { 5, 3 }, // L12
+            { 5, 3 }, // L13
+            { 5, 3 }, // L14
+            { 5, 3 }, // L15
+            { 5, 3 }, // L16
+            { 5, 4 }, // L17
+            { 5, 4 }, // L18
+            { 5, 4 }, // L19
+            { 5, 4 }, // L20
+    };
+
+    /** True when the class is one the app treats as a spellcaster (full or pact). */
+    public static boolean isCaster(String clazz) {
+        if (clazz == null) return false;
+        String key = clazz.trim().toLowerCase();
+        return FULL_CASTERS.contains(key) || PACT_CASTER.equals(key);
+    }
+
+    /**
+     * Maximum spell slots available at a class/level, as {@code spellLevel -> maxSlots}
+     * (insertion-ordered by spell level). Empty for non-casters. Levels are clamped to
+     * {@value #MAX_LEVEL}.
+     */
+    public static Map<Integer, Integer> spellSlotsFor(String clazz, int level) {
+        Map<Integer, Integer> slots = new LinkedHashMap<>();
+        if (clazz == null || level < 1) return slots;
+        String key = clazz.trim().toLowerCase();
+        int idx = Math.min(level, MAX_LEVEL) - 1;
+
+        if (FULL_CASTERS.contains(key)) {
+            int[] row = FULL_CASTER_SLOTS[idx];
+            for (int i = 0; i < row.length; i++) {
+                if (row[i] > 0) slots.put(i + 1, row[i]);
+            }
+        } else if (PACT_CASTER.equals(key)) {
+            int[] pact = PACT_SLOTS[idx];
+            slots.put(pact[0], pact[1]);
+        }
+        return slots;
     }
 }

--- a/src/main/java/com/moo/charactermanagerservice/services/LevelUpService.java
+++ b/src/main/java/com/moo/charactermanagerservice/services/LevelUpService.java
@@ -1,11 +1,18 @@
 package com.moo.charactermanagerservice.services;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moo.charactermanagerservice.dto.LevelUpPreview;
 import com.moo.charactermanagerservice.models.PC;
 import com.moo.charactermanagerservice.progression.ClassProgression;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Server-authoritative level-up rules engine (single-class, D&D 5e 2024).
@@ -16,19 +23,30 @@ import org.springframework.web.server.ResponseStatusException;
  * tested in isolation (no repo, no Spring context, no security).
  *
  * <p><strong>HP policy (Phase 1):</strong> fixed average — {@code averageHitDieValue + CON mod},
- * floored at {@value #MIN_HP_PER_LEVEL} per level (5e minimum). Rolled HP is a future seam: it
- * would swap the {@link #hpGain} strategy without touching callers.
+ * floored at {@value #MIN_HP_PER_LEVEL} per level (5e minimum). Rolled HP is a future seam.
  *
- * <p><strong>Multiclass seam:</strong> today total level == single class level, so hit die keys
- * off {@code pc.clazz} and proficiency bonus off {@code pc.level}. When multiclassing lands,
- * hit-die/feature lookups move to {@code (class, classLevel)} while proficiency bonus stays on
- * total level — only the inputs change, not this contract.
+ * <p><strong>Spell slots (Phase 2):</strong> for caster classes, the {@code spellSlots} JSON-as-TEXT
+ * column is rebuilt from {@link ClassProgression#spellSlotsFor} — {@code max} is set from the table
+ * for the new level while the player's {@code used} count is preserved (clamped to the new max).
+ * Non-casters are left untouched. This is the first phase that parses the JSON columns, so it is
+ * defensive about null/blank/malformed values.
+ *
+ * <p><strong>Multiclass seam:</strong> today total level == single class level, so all tables key
+ * off {@code pc.clazz} / {@code pc.level}. When multiclassing lands, hit-die/slot lookups move to
+ * {@code (class, classLevel)} (slots via the multiclass caster-level rule) while proficiency bonus
+ * stays on total level — only the inputs change, not this contract.
  */
 @Service
 public class LevelUpService {
 
     /** A character always gains at least this much HP per level, even with a CON penalty. */
     private static final int MIN_HP_PER_LEVEL = 1;
+
+    private final ObjectMapper objectMapper;
+
+    public LevelUpService(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
 
     /** Compute — without persisting — what advancing one level would grant. */
     public LevelUpPreview preview(PC pc) {
@@ -48,13 +66,16 @@ public class LevelUpService {
                 hpGained,
                 nz(pc.getHpMax()) + hpGained,
                 ClassProgression.proficiencyBonusForLevel(currentLevel),
-                ClassProgression.proficiencyBonusForLevel(newLevel)
+                ClassProgression.proficiencyBonusForLevel(newLevel),
+                currentMaxSlots(pc),
+                ClassProgression.spellSlotsFor(pc.getClazz(), newLevel)
         );
     }
 
     /**
      * Mutate the given (managed) PC in place to its next level: bump level, add the HP gain to
-     * both max and current HP, and recompute the proficiency bonus. The caller persists.
+     * both max and current HP, recompute the proficiency bonus, and (for casters) rebuild the
+     * spell-slot map. The caller persists.
      */
     public PC applyLevelUp(PC pc) {
         int currentLevel = currentLevel(pc);
@@ -69,6 +90,10 @@ public class LevelUpService {
         pc.setHpMax((short) (nz(pc.getHpMax()) + hpGained));
         pc.setHpCurrent((short) (nz(pc.getHpCurrent()) + hpGained));
         pc.setProfBonus((short) ClassProgression.proficiencyBonusForLevel(newLevel));
+
+        if (ClassProgression.isCaster(pc.getClazz())) {
+            pc.setSpellSlots(rebuildSpellSlots(pc, newLevel));
+        }
         return pc;
     }
 
@@ -86,6 +111,69 @@ public class LevelUpService {
                     "Character is already at the maximum level (" + ClassProgression.MAX_LEVEL + ")");
         }
     }
+
+    // ── Spell-slot handling ──────────────────────────────────────────────────────
+
+    /**
+     * Rebuild the {@code spellSlots} JSON for the new level: {@code max} comes from the class
+     * table, {@code used} is carried over from the current slots (clamped to the new max), and
+     * spell levels newly unlocked start at {@code used = 0}. Ordered by spell level.
+     */
+    private String rebuildSpellSlots(PC pc, int newLevel) {
+        Map<Integer, Integer> target = ClassProgression.spellSlotsFor(pc.getClazz(), newLevel);
+        Map<Integer, SlotState> existing = parseSlots(pc.getSpellSlots());
+
+        Map<String, Map<String, Integer>> rebuilt = new LinkedHashMap<>();
+        target.forEach((spellLevel, max) -> {
+            SlotState prior = existing.get(spellLevel);
+            int used = prior == null ? 0 : Math.min(prior.used(), max);
+            Map<String, Integer> entry = new LinkedHashMap<>();
+            entry.put("max", max);
+            entry.put("used", used);
+            rebuilt.put(String.valueOf(spellLevel), entry);
+        });
+
+        try {
+            return objectMapper.writeValueAsString(rebuilt);
+        } catch (JsonProcessingException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                    "Failed to serialize spell slots");
+        }
+    }
+
+    /** Current {@code spellLevel -> max} for the preview (sorted; empty if none/malformed). */
+    private Map<Integer, Integer> currentMaxSlots(PC pc) {
+        Map<Integer, Integer> out = new TreeMap<>();
+        parseSlots(pc.getSpellSlots()).forEach((lvl, state) -> out.put(lvl, state.max()));
+        return out;
+    }
+
+    /**
+     * Parse the {@code spellSlots} TEXT column into {@code spellLevel -> {max, used}}. Defensive:
+     * null, blank, or malformed JSON yields an empty map rather than failing the level-up.
+     */
+    private Map<Integer, SlotState> parseSlots(String json) {
+        Map<Integer, SlotState> out = new LinkedHashMap<>();
+        if (json == null || json.isBlank()) return out;
+        try {
+            Map<String, Map<String, Integer>> raw =
+                    objectMapper.readValue(json, new TypeReference<>() {});
+            raw.forEach((lvl, state) -> {
+                try {
+                    int max = state.getOrDefault("max", 0);
+                    int used = state.getOrDefault("used", 0);
+                    out.put(Integer.parseInt(lvl), new SlotState(max, used));
+                } catch (NumberFormatException ignored) {
+                    // skip non-numeric spell-level keys
+                }
+            });
+        } catch (JsonProcessingException e) {
+            return new LinkedHashMap<>(); // malformed column — treat as no slots
+        }
+        return out;
+    }
+
+    private record SlotState(int max, int used) {}
 
     /** Null-safe read of a nullable Short stat as a primitive (older PCs may have null combat stats). */
     private static int nz(Short value) {

--- a/src/test/java/com/moo/charactermanagerservice/controllers/PCControllerTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/controllers/PCControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.*;
@@ -171,7 +172,7 @@ class PCControllerTest {
 
     @Test
     void previewLevelUp_returns200_withPreview() {
-        LevelUpPreview preview = new LevelUpPreview(4, 5, 10, 3, 9, 39, 2, 3);
+        LevelUpPreview preview = new LevelUpPreview(4, 5, 10, 3, 9, 39, 2, 3, Map.of(), Map.of());
         when(pcService.previewLevelUp(1L, ownerId)).thenReturn(preview);
 
         ResponseEntity<LevelUpPreview> response = pcController.previewLevelUp(1L, auth);

--- a/src/test/java/com/moo/charactermanagerservice/services/LevelUpServiceTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/services/LevelUpServiceTest.java
@@ -1,5 +1,6 @@
 package com.moo.charactermanagerservice.services;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moo.charactermanagerservice.dto.LevelUpPreview;
 import com.moo.charactermanagerservice.models.PC;
 import org.junit.jupiter.api.Test;
@@ -10,12 +11,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Pure unit tests for the level-up rules engine — no repo, no Spring, no security.
- * Covers the deterministic Phase 1 gains: fixed-average HP (hit-die avg + CON mod, floored at 1)
- * and the proficiency-bonus bumps at levels 5/9/13/17.
+ * Covers Phase 1 gains (fixed-average HP, proficiency bumps at 5/9/13/17) and Phase 2
+ * spell-slot progression (full-caster + pact tables, preserving the player's used count).
  */
 class LevelUpServiceTest {
 
-    private final LevelUpService service = new LevelUpService();
+    private final LevelUpService service = new LevelUpService(new ObjectMapper());
 
     /** Build a minimal PC with the stats Phase 1 touches. */
     private static PC pc(String clazz, int level, int con, int hpMax, int hpCurrent) {
@@ -141,5 +142,76 @@ class LevelUpServiceTest {
         assertThatThrownBy(() -> service.preview(pc))
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(409));
+    }
+
+    // --- spell-slot progression (Phase 2) ---
+
+    @Test
+    void preview_fullCaster_reportsNewSlotTable() {
+        PC bard = pc("Bard", 7, 14, 50, 50);
+        bard.setSpellSlots("{\"1\":{\"max\":4,\"used\":2},\"2\":{\"max\":3,\"used\":0},\"3\":{\"max\":3,\"used\":0},\"4\":{\"max\":1,\"used\":0}}");
+
+        LevelUpPreview p = service.preview(bard);
+
+        // Bard 7 -> 8: full-caster row becomes 4/3/3/2
+        assertThat(p.newSpellSlots()).containsExactlyInAnyOrderEntriesOf(
+                java.util.Map.of(1, 4, 2, 3, 3, 3, 4, 2));
+        assertThat(p.currentSpellSlots()).containsEntry(4, 1);
+    }
+
+    @Test
+    void applyLevelUp_fullCaster_rebuildsSlotsPreservingUsed() {
+        PC bard = pc("Bard", 7, 14, 50, 50);
+        bard.setSpellSlots("{\"1\":{\"max\":4,\"used\":2},\"4\":{\"max\":1,\"used\":1}}");
+
+        service.applyLevelUp(bard);
+
+        // L8: level-4 max grows 1 -> 2 but used (1) is preserved; level-1 used (2) preserved.
+        assertThat(bard.getSpellSlots()).contains("\"4\":{\"max\":2,\"used\":1}");
+        assertThat(bard.getSpellSlots()).contains("\"1\":{\"max\":4,\"used\":2}");
+    }
+
+    @Test
+    void applyLevelUp_pactCaster_advancesPactSlotLevel() {
+        PC warlock = pc("Warlock", 4, 14, 30, 30);
+        warlock.setSpellSlots("{\"2\":{\"max\":2,\"used\":1}}");
+
+        service.applyLevelUp(warlock);
+
+        // Warlock 4 -> 5: pact slots move to spell level 3, two slots, used resets (new level).
+        assertThat(warlock.getSpellSlots()).isEqualTo("{\"3\":{\"max\":2,\"used\":0}}");
+    }
+
+    @Test
+    void applyLevelUp_nonCaster_leavesSlotsUntouched() {
+        PC fighter = pc("Fighter", 4, 16, 30, 30);
+        fighter.setSpellSlots("{}");
+
+        service.applyLevelUp(fighter);
+
+        assertThat(fighter.getSpellSlots()).isEqualTo("{}");
+        assertThat(service.preview(pc("Fighter", 5, 16, 39, 39)).newSpellSlots()).isEmpty();
+    }
+
+    @Test
+    void applyLevelUp_clampsUsedToNewMax() {
+        PC bard = pc("Bard", 7, 14, 50, 50);
+        // Corrupt/overspent used count well above the table max.
+        bard.setSpellSlots("{\"1\":{\"max\":4,\"used\":9}}");
+
+        service.applyLevelUp(bard);
+
+        assertThat(bard.getSpellSlots()).contains("\"1\":{\"max\":4,\"used\":4}");
+    }
+
+    @Test
+    void applyLevelUp_caster_survivesMalformedSlotJson() {
+        PC wizard = pc("Wizard", 2, 14, 14, 14);
+        wizard.setSpellSlots("not-valid-json");
+
+        service.applyLevelUp(wizard);
+
+        // Malformed prior slots -> rebuilt fresh from the L3 table (4/2), used = 0.
+        assertThat(wizard.getSpellSlots()).isEqualTo("{\"1\":{\"max\":4,\"used\":0},\"2\":{\"max\":2,\"used\":0}}");
     }
 }

--- a/src/test/java/com/moo/charactermanagerservice/services/PCServiceTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/services/PCServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -166,7 +167,7 @@ class PCServiceTest {
 
     @Test
     void previewLevelUp_returnsPreview_whenOwner() {
-        LevelUpPreview preview = new LevelUpPreview(4, 5, 8, 2, 7, 39, 2, 3);
+        LevelUpPreview preview = new LevelUpPreview(4, 5, 8, 2, 7, 39, 2, 3, Map.of(), Map.of());
         when(pcRepository.findById(1L)).thenReturn(Optional.of(pc));
         when(levelUpService.preview(pc)).thenReturn(preview);
 


### PR DESCRIPTION
Extends the server-authoritative level-up engine with per-class spell-slot progression. ClassProgression gains the full-caster table (bard/cleric/druid/ sorcerer/wizard) and warlock pact-magic table, plus spellSlotsFor(clazz, level) and isCaster(). The caster set intentionally matches what the app already models (frontend SPELLCASTING_CLASSES + starting slots) — paladin/ranger are excluded because the app does not represent them as casters; consistency with the current data model wins over 2024 half-caster rules.

On level-up, LevelUpService rebuilds the spellSlots JSON: max comes from the table for the new level, the player's `used` count is preserved (clamped to the new max), newly unlocked levels start at used=0, and non-casters are untouched. This is the first phase to parse the JSON-as-TEXT columns, so it injects an ObjectMapper and is defensive about null/blank/malformed values. LevelUpPreview now carries current/new slot maps so the SPA can render the deltas.

Tests: LevelUpServiceTest +6 (full-caster table, pact advance, non-caster untouched, used preserved + clamped, malformed JSON). 120 tests green.