### PR TITLE
feat: add subclass-selection mechanism to level-up (Phase 3, no content)

### DIFF
--- a/src/main/java/com/moo/charactermanagerservice/controllers/PCController.java
+++ b/src/main/java/com/moo/charactermanagerservice/controllers/PCController.java
@@ -1,6 +1,7 @@
 package com.moo.charactermanagerservice.controllers;
 
 import com.moo.charactermanagerservice.dto.LevelUpPreview;
+import com.moo.charactermanagerservice.dto.LevelUpRequest;
 import com.moo.charactermanagerservice.dto.User;
 import com.moo.charactermanagerservice.models.PC;
 import com.moo.charactermanagerservice.services.PCService;
@@ -57,9 +58,11 @@ public class PCController {
     }
 
     @PostMapping("/{id}/level-up")
-    public ResponseEntity<PC> levelUp(@PathVariable Long id, Authentication authentication) {
+    public ResponseEntity<PC> levelUp(@PathVariable Long id, Authentication authentication,
+                                      @RequestBody(required = false) LevelUpRequest request) {
         User user = (User) authentication.getPrincipal();
-        return ResponseEntity.ok(pcService.levelUpPC(id, user.getUuid()));
+        String chosenSubclass = request == null ? null : request.subclass();
+        return ResponseEntity.ok(pcService.levelUpPC(id, user.getUuid(), chosenSubclass));
     }
 
     @DeleteMapping("/delete/{id}")

--- a/src/main/java/com/moo/charactermanagerservice/dto/LevelUpPreview.java
+++ b/src/main/java/com/moo/charactermanagerservice/dto/LevelUpPreview.java
@@ -1,15 +1,17 @@
 package com.moo.charactermanagerservice.dto;
 
+import java.util.List;
 import java.util.Map;
 
 /**
  * Read-only projection of what advancing one level would grant, computed server-side so the
- * SPA can render the deltas before the user commits. No persistence and no player choices.
+ * SPA can render the deltas before the user commits.
  *
- * <p>Phase 1: deterministic gains (HP via fixed average, proficiency bonus). Phase 2 adds the
- * spell-slot picture — {@code spellLevel -> maxSlots} before and after the level — which is
- * empty for non-casters. Later phases that introduce choices (subclass, ASI/feat, spells) add
- * a separate request contract.
+ * <p>Phase 1: deterministic gains (HP via fixed average, proficiency bonus). Phase 2: the
+ * spell-slot picture — {@code spellLevel -> maxSlots} before and after — empty for non-casters.
+ * Phase 3: whether a subclass choice is due at the new level ({@code subclassDue}) and the
+ * selectable names ({@code subclassOptions}); the options list is empty until catalog content
+ * is authored, so the SPA shows the picker only when there is something to pick.
  */
 public record LevelUpPreview(
         int currentLevel,
@@ -21,5 +23,7 @@ public record LevelUpPreview(
         int currentProfBonus,
         int newProfBonus,
         Map<Integer, Integer> currentSpellSlots,
-        Map<Integer, Integer> newSpellSlots
+        Map<Integer, Integer> newSpellSlots,
+        boolean subclassDue,
+        List<String> subclassOptions
 ) {}

--- a/src/main/java/com/moo/charactermanagerservice/dto/LevelUpRequest.java
+++ b/src/main/java/com/moo/charactermanagerservice/dto/LevelUpRequest.java
@@ -1,0 +1,9 @@
+package com.moo.charactermanagerservice.dto;
+
+/**
+ * Optional player choices supplied when committing a level-up. The body is optional — levels
+ * with no choices send nothing. Phase 3 adds {@code subclass} (the chosen subclass name when a
+ * class reaches its subclass-selection level). Later phases extend this with ASI/feat and spell
+ * selections rather than widening the URL.
+ */
+public record LevelUpRequest(String subclass) {}

--- a/src/main/java/com/moo/charactermanagerservice/progression/ClassProgression.java
+++ b/src/main/java/com/moo/charactermanagerservice/progression/ClassProgression.java
@@ -1,6 +1,7 @@
 package com.moo.charactermanagerservice.progression;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -167,5 +168,48 @@ public final class ClassProgression {
             slots.put(pact[0], pact[1]);
         }
         return slots;
+    }
+
+    // ── Subclass timing & catalog (Phase 3 — mechanism only) ────────────────────
+    // The level at which each class chooses its subclass. Sorcerer/Warlock are level 1
+    // to match the app's existing creation flow; every other class is level 3 (2024 PHB).
+    // Unmapped classes default to 3.
+    //
+    // The CATALOG (valid subclass names per class) is intentionally EMPTY for now: this
+    // phase ships the selection *mechanism* (timing, preview signal, server validation,
+    // request plumbing) without authoring subclass content. The flow stays dormant — the
+    // preview reports no options and nothing is required — and activates automatically,
+    // with no code change, once a class is given catalog entries here.
+
+    private static final int DEFAULT_SUBCLASS_LEVEL = 3;
+
+    private static final Map<String, Integer> SUBCLASS_LEVEL = Map.ofEntries(
+            Map.entry("sorcerer", 1),
+            Map.entry("warlock", 1),
+            Map.entry("bard", 3),
+            Map.entry("cleric", 3),
+            Map.entry("druid", 3),
+            Map.entry("wizard", 3),
+            Map.entry("barbarian", 3),
+            Map.entry("fighter", 3),
+            Map.entry("monk", 3),
+            Map.entry("paladin", 3),
+            Map.entry("ranger", 3),
+            Map.entry("rogue", 3)
+    );
+
+    /** Valid subclass names per class. Empty until content is authored (see note above). */
+    private static final Map<String, List<String>> SUBCLASS_CATALOG = Map.of();
+
+    /** The character level at which the given class selects its subclass. */
+    public static int subclassLevelFor(String clazz) {
+        if (clazz == null) return DEFAULT_SUBCLASS_LEVEL;
+        return SUBCLASS_LEVEL.getOrDefault(clazz.trim().toLowerCase(), DEFAULT_SUBCLASS_LEVEL);
+    }
+
+    /** Selectable subclass names for a class (empty when no catalog content exists yet). */
+    public static List<String> subclassesFor(String clazz) {
+        if (clazz == null) return List.of();
+        return SUBCLASS_CATALOG.getOrDefault(clazz.trim().toLowerCase(), List.of());
     }
 }

--- a/src/main/java/com/moo/charactermanagerservice/services/LevelUpService.java
+++ b/src/main/java/com/moo/charactermanagerservice/services/LevelUpService.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
@@ -68,16 +69,25 @@ public class LevelUpService {
                 ClassProgression.proficiencyBonusForLevel(currentLevel),
                 ClassProgression.proficiencyBonusForLevel(newLevel),
                 currentMaxSlots(pc),
-                ClassProgression.spellSlotsFor(pc.getClazz(), newLevel)
+                ClassProgression.spellSlotsFor(pc.getClazz(), newLevel),
+                subclassDue(pc, newLevel),
+                ClassProgression.subclassesFor(pc.getClazz())
         );
+    }
+
+    /** Convenience overload for level-ups with no player choices. */
+    public PC applyLevelUp(PC pc) {
+        return applyLevelUp(pc, null);
     }
 
     /**
      * Mutate the given (managed) PC in place to its next level: bump level, add the HP gain to
-     * both max and current HP, recompute the proficiency bonus, and (for casters) rebuild the
-     * spell-slot map. The caller persists.
+     * both max and current HP, recompute the proficiency bonus, rebuild the spell-slot map (for
+     * casters), and apply the chosen subclass when one is due. The caller persists.
+     *
+     * @param chosenSubclass the player's subclass selection, or {@code null} when none applies
      */
-    public PC applyLevelUp(PC pc) {
+    public PC applyLevelUp(PC pc, String chosenSubclass) {
         int currentLevel = currentLevel(pc);
         assertCanLevelUp(currentLevel);
 
@@ -85,6 +95,9 @@ public class LevelUpService {
         int hitDie = ClassProgression.hitDie(pc.getClazz());
         int conMod = ClassProgression.abilityModifier(nz(pc.getAbilityCon()));
         int hpGained = hpGain(hitDie, conMod);
+
+        // Validate the subclass choice against the new level before mutating anything.
+        applySubclassChoice(pc, newLevel, chosenSubclass);
 
         pc.setLevel((short) newLevel);
         pc.setHpMax((short) (nz(pc.getHpMax()) + hpGained));
@@ -110,6 +123,49 @@ public class LevelUpService {
             throw new ResponseStatusException(HttpStatus.CONFLICT,
                     "Character is already at the maximum level (" + ClassProgression.MAX_LEVEL + ")");
         }
+    }
+
+    // ── Subclass selection (Phase 3) ─────────────────────────────────────────────
+
+    /** A subclass choice is due when the new level is the class's grant level and none is set yet. */
+    private boolean subclassDue(PC pc, int newLevel) {
+        return newLevel == ClassProgression.subclassLevelFor(pc.getClazz())
+                && isBlank(pc.getSubclass());
+    }
+
+    /**
+     * Validate and apply the player's subclass choice for this level. Server-authoritative:
+     * a choice is only accepted when it is actually due, and (once catalog content exists) it
+     * must be a known subclass for the class. With the catalog empty, the flow is dormant — no
+     * choice is required and none is offered — so today this is effectively a no-op.
+     */
+    private void applySubclassChoice(PC pc, int newLevel, String chosen) {
+        boolean due = subclassDue(pc, newLevel);
+        List<String> options = ClassProgression.subclassesFor(pc.getClazz());
+
+        if (chosen != null && !chosen.isBlank()) {
+            String choice = chosen.trim();
+            if (!due) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "A subclass cannot be selected for " + pc.getClazz() + " at level " + newLevel);
+            }
+            if (!options.isEmpty() && options.stream().noneMatch(o -> o.equalsIgnoreCase(choice))) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "'" + choice + "' is not a valid subclass for " + pc.getClazz());
+            }
+            pc.setSubclass(choice);
+            return;
+        }
+
+        // No choice supplied: only an error when a real catalog exists and a pick is due.
+        if (due && !options.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "A subclass must be selected at level " + newLevel);
+        }
+    }
+
+    private static boolean isBlank(String s) {
+        return s == null || s.isBlank();
     }
 
     // ── Spell-slot handling ──────────────────────────────────────────────────────

--- a/src/main/java/com/moo/charactermanagerservice/services/PCService.java
+++ b/src/main/java/com/moo/charactermanagerservice/services/PCService.java
@@ -62,13 +62,16 @@ public class PCService {
 
     /**
      * Advance this PC one level and persist. Ownership is enforced and the rules are applied
-     * server-side ({@link LevelUpService}); the client supplies no stats. {@code @Transactional}
-     * keeps the load-modify-save atomic so a level can't be applied twice from a single request.
+     * server-side ({@link LevelUpService}); the client supplies only choices (e.g. a subclass
+     * selection), never computed stats. {@code @Transactional} keeps the load-modify-save atomic
+     * so a level can't be applied twice from a single request.
+     *
+     * @param chosenSubclass the player's subclass selection, or {@code null} when none applies
      */
     @Transactional
-    public PC levelUpPC(Long id, UUID userId) {
+    public PC levelUpPC(Long id, UUID userId, String chosenSubclass) {
         PC pc = findPCByIdForUser(id, userId);
-        levelUpService.applyLevelUp(pc);
+        levelUpService.applyLevelUp(pc, chosenSubclass);
         return pcRepository.save(pc);
     }
 

--- a/src/test/java/com/moo/charactermanagerservice/controllers/PCControllerTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/controllers/PCControllerTest.java
@@ -1,6 +1,7 @@
 package com.moo.charactermanagerservice.controllers;
 
 import com.moo.charactermanagerservice.dto.LevelUpPreview;
+import com.moo.charactermanagerservice.dto.LevelUpRequest;
 import com.moo.charactermanagerservice.dto.User;
 import com.moo.charactermanagerservice.exceptions.PCNotFoundException;
 import com.moo.charactermanagerservice.models.PC;
@@ -172,7 +173,7 @@ class PCControllerTest {
 
     @Test
     void previewLevelUp_returns200_withPreview() {
-        LevelUpPreview preview = new LevelUpPreview(4, 5, 10, 3, 9, 39, 2, 3, Map.of(), Map.of());
+        LevelUpPreview preview = new LevelUpPreview(4, 5, 10, 3, 9, 39, 2, 3, Map.of(), Map.of(), false, List.of());
         when(pcService.previewLevelUp(1L, ownerId)).thenReturn(preview);
 
         ResponseEntity<LevelUpPreview> response = pcController.previewLevelUp(1L, auth);
@@ -195,30 +196,39 @@ class PCControllerTest {
 
     @Test
     void levelUp_returns200_whenOwner() {
-        when(pcService.levelUpPC(1L, ownerId)).thenReturn(pc);
+        when(pcService.levelUpPC(1L, ownerId, null)).thenReturn(pc);
 
-        ResponseEntity<PC> response = pcController.levelUp(1L, auth);
+        ResponseEntity<PC> response = pcController.levelUp(1L, auth, null);
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).isSameAs(pc);
     }
 
     @Test
+    void levelUp_passesSubclassChoiceFromBody() {
+        when(pcService.levelUpPC(1L, ownerId, "Life Domain")).thenReturn(pc);
+
+        pcController.levelUp(1L, auth, new LevelUpRequest("Life Domain"));
+
+        verify(pcService).levelUpPC(1L, ownerId, "Life Domain");
+    }
+
+    @Test
     void levelUp_propagates403_whenNotOwner() {
-        when(pcService.levelUpPC(1L, ownerId))
+        when(pcService.levelUpPC(1L, ownerId, null))
                 .thenThrow(new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied"));
 
-        assertThatThrownBy(() -> pcController.levelUp(1L, auth))
+        assertThatThrownBy(() -> pcController.levelUp(1L, auth, null))
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(403));
     }
 
     @Test
     void levelUp_propagates409_whenAtMaxLevel() {
-        when(pcService.levelUpPC(1L, ownerId))
+        when(pcService.levelUpPC(1L, ownerId, null))
                 .thenThrow(new ResponseStatusException(HttpStatus.CONFLICT, "Character is already at the maximum level (20)"));
 
-        assertThatThrownBy(() -> pcController.levelUp(1L, auth))
+        assertThatThrownBy(() -> pcController.levelUp(1L, auth, null))
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(409));
     }

--- a/src/test/java/com/moo/charactermanagerservice/services/LevelUpServiceTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/services/LevelUpServiceTest.java
@@ -214,4 +214,64 @@ class LevelUpServiceTest {
         // Malformed prior slots -> rebuilt fresh from the L3 table (4/2), used = 0.
         assertThat(wizard.getSpellSlots()).isEqualTo("{\"1\":{\"max\":4,\"used\":0},\"2\":{\"max\":2,\"used\":0}}");
     }
+
+    // --- subclass selection mechanism (Phase 3 — catalog intentionally empty) ---
+
+    @Test
+    void preview_subclassDue_atGrantLevelWithNoSubclass() {
+        // Cleric grant level is 3; leveling 2 -> 3 with no subclass yet.
+        LevelUpPreview p = service.preview(pc("Cleric", 2, 14, 14, 14));
+        assertThat(p.subclassDue()).isTrue();
+        assertThat(p.subclassOptions()).isEmpty(); // no catalog content yet
+    }
+
+    @Test
+    void preview_subclassNotDue_whenAlreadyHasSubclass() {
+        PC cleric = pc("Cleric", 2, 14, 14, 14);
+        cleric.setSubclass("Life Domain");
+        assertThat(service.preview(cleric).subclassDue()).isFalse();
+    }
+
+    @Test
+    void preview_subclassNotDue_atNonGrantLevel() {
+        // Cleric 4 -> 5 is past the grant level.
+        assertThat(service.preview(pc("Cleric", 4, 14, 30, 30)).subclassDue()).isFalse();
+    }
+
+    @Test
+    void applyLevelUp_setsChosenSubclass_whenDue() {
+        // Catalog empty -> server can't validate membership, so any non-blank choice is accepted.
+        PC cleric = pc("Cleric", 2, 14, 14, 14);
+
+        service.applyLevelUp(cleric, "Life Domain");
+
+        assertThat(cleric.getLevel()).isEqualTo((short) 3);
+        assertThat(cleric.getSubclass()).isEqualTo("Life Domain");
+    }
+
+    @Test
+    void applyLevelUp_rejectsSubclass_whenNotDue() {
+        PC cleric = pc("Cleric", 4, 14, 30, 30); // -> 5, past grant level
+        assertThatThrownBy(() -> service.applyLevelUp(cleric, "Life Domain"))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(400));
+    }
+
+    @Test
+    void applyLevelUp_dueButNoChoiceAndEmptyCatalog_proceedsWithoutSubclass() {
+        // With no catalog content the flow is dormant: a level-up still succeeds with no subclass.
+        PC cleric = pc("Cleric", 2, 14, 14, 14);
+
+        service.applyLevelUp(cleric, null);
+
+        assertThat(cleric.getLevel()).isEqualTo((short) 3);
+        assertThat(cleric.getSubclass()).isNull();
+    }
+
+    @Test
+    void applyLevelUp_pactCasterSubclassDueAtCreationLevel_neverFiresOnLevelUp() {
+        // Sorcerer/Warlock grant at level 1, so a subclass is never "due" during a level-up.
+        assertThat(service.preview(pc("Sorcerer", 4, 14, 24, 24)).subclassDue()).isFalse();
+        assertThat(service.preview(pc("Warlock", 1, 14, 9, 9)).subclassDue()).isFalse();
+    }
 }

--- a/src/test/java/com/moo/charactermanagerservice/services/PCServiceTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/services/PCServiceTest.java
@@ -143,23 +143,33 @@ class PCServiceTest {
         when(pcRepository.findById(1L)).thenReturn(Optional.of(pc));
         when(pcRepository.save(pc)).thenReturn(pc);
 
-        PC result = pcService.levelUpPC(1L, ownerId);
+        PC result = pcService.levelUpPC(1L, ownerId, null);
 
         assertThat(result).isSameAs(pc);
-        verify(levelUpService).applyLevelUp(pc);
+        verify(levelUpService).applyLevelUp(pc, null);
         verify(pcRepository).save(pc);
+    }
+
+    @Test
+    void levelUpPC_passesSubclassChoiceToRulesEngine() {
+        when(pcRepository.findById(1L)).thenReturn(Optional.of(pc));
+        when(pcRepository.save(pc)).thenReturn(pc);
+
+        pcService.levelUpPC(1L, ownerId, "Life Domain");
+
+        verify(levelUpService).applyLevelUp(pc, "Life Domain");
     }
 
     @Test
     void levelUpPC_throws403_whenNotOwner() {
         when(pcRepository.findById(1L)).thenReturn(Optional.of(pc));
 
-        assertThatThrownBy(() -> pcService.levelUpPC(1L, strangerId))
+        assertThatThrownBy(() -> pcService.levelUpPC(1L, strangerId, null))
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value())
                         .isEqualTo(403));
 
-        verify(levelUpService, never()).applyLevelUp(any());
+        verify(levelUpService, never()).applyLevelUp(any(), any());
         verify(pcRepository, never()).save(any());
     }
 
@@ -167,7 +177,7 @@ class PCServiceTest {
 
     @Test
     void previewLevelUp_returnsPreview_whenOwner() {
-        LevelUpPreview preview = new LevelUpPreview(4, 5, 8, 2, 7, 39, 2, 3, Map.of(), Map.of());
+        LevelUpPreview preview = new LevelUpPreview(4, 5, 8, 2, 7, 39, 2, 3, Map.of(), Map.of(), false, List.of());
         when(pcRepository.findById(1L)).thenReturn(Optional.of(pc));
         when(levelUpService.preview(pc)).thenReturn(preview);
 


### PR DESCRIPTION
Builds the server-authoritative plumbing for choosing a subclass on level-up, without authoring subclass content (per decision: mechanism only). The flow is dormant today and activates automatically once catalog entries are added.

- ClassProgression: SUBCLASS_LEVEL grant-level map (sorcerer/warlock = 1 to match the app's creation flow, all others = 3 per 2024 PHB) + subclassLevelFor(), and an intentionally EMPTY SUBCLASS_CATALOG + subclassesFor().
- LevelUpService.applyLevelUp now takes an optional chosen subclass and validates it server-side: a choice is accepted only when actually due (newLevel == grant level AND no subclass yet), must be in the catalog once one exists, and is rejected (400) when supplied at the wrong level. With the catalog empty, no choice is required or offered, so behaviour is unchanged. LevelUpPreview gains subclassDue + subclassOptions so the SPA shows a picker only when there is something to pick.
- New LevelUpRequest body on POST /{id}/level-up (optional); PCController/PCService thread the choice through.

Tests: LevelUpServiceTest +7 (grant-level timing, due/not-due, accept-when-due, reject-when-not-due, dormant empty-catalog) plus controller/service plumbing. 129 tests green.