### PR TITLE
feat: add Ability Score Improvement to level-up (Phase 4, ASI only)

### DIFF
--- a/src/main/java/com/moo/charactermanagerservice/controllers/PCController.java
+++ b/src/main/java/com/moo/charactermanagerservice/controllers/PCController.java
@@ -61,8 +61,7 @@ public class PCController {
     public ResponseEntity<PC> levelUp(@PathVariable Long id, Authentication authentication,
                                       @RequestBody(required = false) LevelUpRequest request) {
         User user = (User) authentication.getPrincipal();
-        String chosenSubclass = request == null ? null : request.subclass();
-        return ResponseEntity.ok(pcService.levelUpPC(id, user.getUuid(), chosenSubclass));
+        return ResponseEntity.ok(pcService.levelUpPC(id, user.getUuid(), request));
     }
 
     @DeleteMapping("/delete/{id}")

--- a/src/main/java/com/moo/charactermanagerservice/dto/LevelUpPreview.java
+++ b/src/main/java/com/moo/charactermanagerservice/dto/LevelUpPreview.java
@@ -25,5 +25,6 @@ public record LevelUpPreview(
         Map<Integer, Integer> currentSpellSlots,
         Map<Integer, Integer> newSpellSlots,
         boolean subclassDue,
-        List<String> subclassOptions
+        List<String> subclassOptions,
+        boolean asiDue
 ) {}

--- a/src/main/java/com/moo/charactermanagerservice/dto/LevelUpRequest.java
+++ b/src/main/java/com/moo/charactermanagerservice/dto/LevelUpRequest.java
@@ -1,9 +1,14 @@
 package com.moo.charactermanagerservice.dto;
 
+import java.util.Map;
+
 /**
  * Optional player choices supplied when committing a level-up. The body is optional — levels
- * with no choices send nothing. Phase 3 adds {@code subclass} (the chosen subclass name when a
- * class reaches its subclass-selection level). Later phases extend this with ASI/feat and spell
- * selections rather than widening the URL.
+ * with no choices send nothing.
+ *
+ * <p>Phase 3: {@code subclass} (the chosen subclass name when a class reaches its
+ * subclass-selection level). Phase 4: {@code abilityIncreases} — the Ability Score Improvement
+ * allocation as {@code ABILITY -> points}, e.g. {@code {"CON":2}} or {@code {"STR":1,"DEX":1}}.
+ * Later phases extend this (feats, spell selections) rather than widening the URL.
  */
-public record LevelUpRequest(String subclass) {}
+public record LevelUpRequest(String subclass, Map<String, Integer> abilityIncreases) {}

--- a/src/main/java/com/moo/charactermanagerservice/progression/ClassProgression.java
+++ b/src/main/java/com/moo/charactermanagerservice/progression/ClassProgression.java
@@ -212,4 +212,25 @@ public final class ClassProgression {
         if (clazz == null) return List.of();
         return SUBCLASS_CATALOG.getOrDefault(clazz.trim().toLowerCase(), List.of());
     }
+
+    // ── Ability Score Improvement levels (Phase 4) ──────────────────────────────
+    // Every class gains an ASI (or feat) at 4/8/12/16/19. Fighter and Rogue get extra
+    // ones (Fighter at 6 & 14, Rogue at 10) per the 2024 PHB. Feats are deferred — this
+    // phase implements the ASI choice only.
+
+    private static final Set<Integer> DEFAULT_ASI_LEVELS = Set.of(4, 8, 12, 16, 19);
+
+    private static final Map<String, Set<Integer>> ASI_LEVELS = Map.of(
+            "fighter", Set.of(4, 6, 8, 12, 14, 16, 19),
+            "rogue", Set.of(4, 8, 10, 12, 16, 19)
+    );
+
+    /** Whether the given class receives an Ability Score Improvement at the given level. */
+    public static boolean isAsiLevel(String clazz, int level) {
+        if (clazz == null) return DEFAULT_ASI_LEVELS.contains(level);
+        return ASI_LEVELS.getOrDefault(clazz.trim().toLowerCase(), DEFAULT_ASI_LEVELS).contains(level);
+    }
+
+    /** Maximum value any single ability score can reach via normal advancement. */
+    public static final int MAX_ABILITY_SCORE = 20;
 }

--- a/src/main/java/com/moo/charactermanagerservice/services/LevelUpService.java
+++ b/src/main/java/com/moo/charactermanagerservice/services/LevelUpService.java
@@ -71,37 +71,54 @@ public class LevelUpService {
                 currentMaxSlots(pc),
                 ClassProgression.spellSlotsFor(pc.getClazz(), newLevel),
                 subclassDue(pc, newLevel),
-                ClassProgression.subclassesFor(pc.getClazz())
+                ClassProgression.subclassesFor(pc.getClazz()),
+                ClassProgression.isAsiLevel(pc.getClazz(), newLevel)
         );
     }
 
     /** Convenience overload for level-ups with no player choices. */
     public PC applyLevelUp(PC pc) {
-        return applyLevelUp(pc, null);
+        return applyLevelUp(pc, null, null);
+    }
+
+    /** Convenience overload for a subclass-only choice. */
+    public PC applyLevelUp(PC pc, String chosenSubclass) {
+        return applyLevelUp(pc, chosenSubclass, null);
     }
 
     /**
-     * Mutate the given (managed) PC in place to its next level: bump level, add the HP gain to
-     * both max and current HP, recompute the proficiency bonus, rebuild the spell-slot map (for
-     * casters), and apply the chosen subclass when one is due. The caller persists.
+     * Mutate the given (managed) PC in place to its next level: validate and apply the player's
+     * choices (subclass, Ability Score Improvement), then bump level, add HP, recompute the
+     * proficiency bonus, and rebuild the spell-slot map (for casters). The caller persists.
      *
-     * @param chosenSubclass the player's subclass selection, or {@code null} when none applies
+     * <p>HP order matters: ability scores are applied <em>before</em> HP, so the new level's gain
+     * uses the post-ASI CON modifier, and a CON-modifier increase additionally grants HP to every
+     * prior level (the 5e retroactive rule).
+     *
+     * @param chosenSubclass   the player's subclass selection, or {@code null} when none applies
+     * @param abilityIncreases the ASI allocation ({@code ABILITY -> points}), or {@code null}
      */
-    public PC applyLevelUp(PC pc, String chosenSubclass) {
+    public PC applyLevelUp(PC pc, String chosenSubclass, Map<String, Integer> abilityIncreases) {
         int currentLevel = currentLevel(pc);
         assertCanLevelUp(currentLevel);
-
         int newLevel = currentLevel + 1;
-        int hitDie = ClassProgression.hitDie(pc.getClazz());
-        int conMod = ClassProgression.abilityModifier(nz(pc.getAbilityCon()));
-        int hpGained = hpGain(hitDie, conMod);
 
-        // Validate the subclass choice against the new level before mutating anything.
+        int oldConMod = ClassProgression.abilityModifier(nz(pc.getAbilityCon()));
+
+        // Validate + apply choices first — the ASI can change ability scores (including CON).
         applySubclassChoice(pc, newLevel, chosenSubclass);
+        applyAbilityScoreImprovement(pc, newLevel, abilityIncreases);
+
+        int newConMod = ClassProgression.abilityModifier(nz(pc.getAbilityCon()));
+        int hitDie = ClassProgression.hitDie(pc.getClazz());
+        int hpGained = hpGain(hitDie, newConMod);
+        // A rise in CON's modifier grants HP to every level you already have (this level's gain
+        // above already reflects the new modifier, so only the prior levels are added here).
+        int retroactiveHp = (newLevel - 1) * (newConMod - oldConMod);
 
         pc.setLevel((short) newLevel);
-        pc.setHpMax((short) (nz(pc.getHpMax()) + hpGained));
-        pc.setHpCurrent((short) (nz(pc.getHpCurrent()) + hpGained));
+        pc.setHpMax((short) (nz(pc.getHpMax()) + hpGained + retroactiveHp));
+        pc.setHpCurrent((short) (nz(pc.getHpCurrent()) + hpGained + retroactiveHp));
         pc.setProfBonus((short) ClassProgression.proficiencyBonusForLevel(newLevel));
 
         if (ClassProgression.isCaster(pc.getClazz())) {
@@ -166,6 +183,88 @@ public class LevelUpService {
 
     private static boolean isBlank(String s) {
         return s == null || s.isBlank();
+    }
+
+    // ── Ability Score Improvement (Phase 4) ──────────────────────────────────────
+
+    private static final List<String> ABILITIES = List.of("STR", "DEX", "CON", "INT", "WIS", "CHA");
+
+    /**
+     * Validate and apply the ASI allocation. Server-authoritative: an allocation is accepted only
+     * at an ASI level, must add exactly 2 points (+2 to one ability or +1 to two distinct ones),
+     * and may not push any score past {@value ClassProgression#MAX_ABILITY_SCORE}. A choice is
+     * required at an ASI level (feats are deferred, so ASI is the only option for now).
+     */
+    private void applyAbilityScoreImprovement(PC pc, int newLevel, Map<String, Integer> increases) {
+        boolean due = ClassProgression.isAsiLevel(pc.getClazz(), newLevel);
+        boolean provided = increases != null && !increases.isEmpty();
+
+        if (!provided) {
+            if (due) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "An ability score improvement is required at level " + newLevel);
+            }
+            return;
+        }
+        if (!due) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "An ability score improvement cannot be applied at level " + newLevel);
+        }
+
+        // Normalize keys and total the points.
+        Map<String, Integer> allocation = new LinkedHashMap<>();
+        int total = 0;
+        for (Map.Entry<String, Integer> e : increases.entrySet()) {
+            String ability = e.getKey() == null ? "" : e.getKey().trim().toUpperCase();
+            Integer points = e.getValue();
+            if (!ABILITIES.contains(ability)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unknown ability: " + e.getKey());
+            }
+            if (points == null || points < 1 || points > 2) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "Each ability increase must be 1 or 2 points");
+            }
+            allocation.merge(ability, points, Integer::sum);
+            total += points;
+        }
+        if (total != 2) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "An ability score improvement must add exactly 2 points (+2 to one ability or +1 to two)");
+        }
+
+        // Validate caps before mutating anything, so a bad allocation leaves the PC untouched.
+        allocation.forEach((ability, points) -> {
+            if (abilityScore(pc, ability) + points > ClassProgression.MAX_ABILITY_SCORE) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        ability + " cannot exceed " + ClassProgression.MAX_ABILITY_SCORE);
+            }
+        });
+        allocation.forEach((ability, points) ->
+                setAbilityScore(pc, ability, (short) (abilityScore(pc, ability) + points)));
+    }
+
+    private int abilityScore(PC pc, String ability) {
+        return switch (ability) {
+            case "STR" -> nz(pc.getAbilityStr());
+            case "DEX" -> nz(pc.getAbilityDex());
+            case "CON" -> nz(pc.getAbilityCon());
+            case "INT" -> nz(pc.getAbilityInt());
+            case "WIS" -> nz(pc.getAbilityWis());
+            case "CHA" -> nz(pc.getAbilityCha());
+            default -> 0;
+        };
+    }
+
+    private void setAbilityScore(PC pc, String ability, short value) {
+        switch (ability) {
+            case "STR" -> pc.setAbilityStr(value);
+            case "DEX" -> pc.setAbilityDex(value);
+            case "CON" -> pc.setAbilityCon(value);
+            case "INT" -> pc.setAbilityInt(value);
+            case "WIS" -> pc.setAbilityWis(value);
+            case "CHA" -> pc.setAbilityCha(value);
+            default -> { /* unreachable — validated above */ }
+        }
     }
 
     // ── Spell-slot handling ──────────────────────────────────────────────────────

--- a/src/main/java/com/moo/charactermanagerservice/services/PCService.java
+++ b/src/main/java/com/moo/charactermanagerservice/services/PCService.java
@@ -1,6 +1,7 @@
 package com.moo.charactermanagerservice.services;
 
 import com.moo.charactermanagerservice.dto.LevelUpPreview;
+import com.moo.charactermanagerservice.dto.LevelUpRequest;
 import com.moo.charactermanagerservice.exceptions.PCNotFoundException;
 import com.moo.charactermanagerservice.models.PC;
 import com.moo.charactermanagerservice.repositories.PCRepository;
@@ -11,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -66,12 +68,14 @@ public class PCService {
      * selection), never computed stats. {@code @Transactional} keeps the load-modify-save atomic
      * so a level can't be applied twice from a single request.
      *
-     * @param chosenSubclass the player's subclass selection, or {@code null} when none applies
+     * @param request the player's level-up choices (subclass, ASI), or {@code null} when none
      */
     @Transactional
-    public PC levelUpPC(Long id, UUID userId, String chosenSubclass) {
+    public PC levelUpPC(Long id, UUID userId, LevelUpRequest request) {
         PC pc = findPCByIdForUser(id, userId);
-        levelUpService.applyLevelUp(pc, chosenSubclass);
+        String subclass = request == null ? null : request.subclass();
+        Map<String, Integer> abilityIncreases = request == null ? null : request.abilityIncreases();
+        levelUpService.applyLevelUp(pc, subclass, abilityIncreases);
         return pcRepository.save(pc);
     }
 

--- a/src/test/java/com/moo/charactermanagerservice/controllers/PCControllerTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/controllers/PCControllerTest.java
@@ -173,7 +173,7 @@ class PCControllerTest {
 
     @Test
     void previewLevelUp_returns200_withPreview() {
-        LevelUpPreview preview = new LevelUpPreview(4, 5, 10, 3, 9, 39, 2, 3, Map.of(), Map.of(), false, List.of());
+        LevelUpPreview preview = new LevelUpPreview(4, 5, 10, 3, 9, 39, 2, 3, Map.of(), Map.of(), false, List.of(), false);
         when(pcService.previewLevelUp(1L, ownerId)).thenReturn(preview);
 
         ResponseEntity<LevelUpPreview> response = pcController.previewLevelUp(1L, auth);
@@ -205,12 +205,13 @@ class PCControllerTest {
     }
 
     @Test
-    void levelUp_passesSubclassChoiceFromBody() {
-        when(pcService.levelUpPC(1L, ownerId, "Life Domain")).thenReturn(pc);
+    void levelUp_passesChoicesFromBody() {
+        LevelUpRequest body = new LevelUpRequest("Life Domain", java.util.Map.of("STR", 2));
+        when(pcService.levelUpPC(1L, ownerId, body)).thenReturn(pc);
 
-        pcController.levelUp(1L, auth, new LevelUpRequest("Life Domain"));
+        pcController.levelUp(1L, auth, body);
 
-        verify(pcService).levelUpPC(1L, ownerId, "Life Domain");
+        verify(pcService).levelUpPC(1L, ownerId, body);
     }
 
     @Test

--- a/src/test/java/com/moo/charactermanagerservice/services/LevelUpServiceTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/services/LevelUpServiceTest.java
@@ -161,14 +161,16 @@ class LevelUpServiceTest {
 
     @Test
     void applyLevelUp_fullCaster_rebuildsSlotsPreservingUsed() {
-        PC bard = pc("Bard", 7, 14, 50, 50);
-        bard.setSpellSlots("{\"1\":{\"max\":4,\"used\":2},\"4\":{\"max\":1,\"used\":1}}");
+        PC bard = pc("Bard", 8, 14, 50, 50); // 8 -> 9 (not an ASI level)
+        bard.setSpellSlots("{\"1\":{\"max\":4,\"used\":2},\"4\":{\"max\":2,\"used\":1}}");
 
         service.applyLevelUp(bard);
 
-        // L8: level-4 max grows 1 -> 2 but used (1) is preserved; level-1 used (2) preserved.
-        assertThat(bard.getSpellSlots()).contains("\"4\":{\"max\":2,\"used\":1}");
+        // L9: level-4 max grows 2 -> 3 but used (1) is preserved; level-1 used (2) preserved;
+        // a new level-5 slot appears.
+        assertThat(bard.getSpellSlots()).contains("\"4\":{\"max\":3,\"used\":1}");
         assertThat(bard.getSpellSlots()).contains("\"1\":{\"max\":4,\"used\":2}");
+        assertThat(bard.getSpellSlots()).contains("\"5\":{\"max\":1,\"used\":0}");
     }
 
     @Test
@@ -195,7 +197,7 @@ class LevelUpServiceTest {
 
     @Test
     void applyLevelUp_clampsUsedToNewMax() {
-        PC bard = pc("Bard", 7, 14, 50, 50);
+        PC bard = pc("Bard", 8, 14, 50, 50); // 8 -> 9 (not an ASI level)
         // Corrupt/overspent used count well above the table max.
         bard.setSpellSlots("{\"1\":{\"max\":4,\"used\":9}}");
 
@@ -273,5 +275,94 @@ class LevelUpServiceTest {
         // Sorcerer/Warlock grant at level 1, so a subclass is never "due" during a level-up.
         assertThat(service.preview(pc("Sorcerer", 4, 14, 24, 24)).subclassDue()).isFalse();
         assertThat(service.preview(pc("Warlock", 1, 14, 9, 9)).subclassDue()).isFalse();
+    }
+
+    // --- Ability Score Improvement (Phase 4) ---
+
+    @Test
+    void preview_asiDue_atAsiLevels() {
+        assertThat(service.preview(pc("Fighter", 3, 14, 28, 28)).asiDue()).isTrue();  // -> 4
+        assertThat(service.preview(pc("Fighter", 4, 14, 38, 38)).asiDue()).isFalse(); // -> 5
+        assertThat(service.preview(pc("Fighter", 5, 14, 44, 44)).asiDue()).isTrue();  // -> 6 (Fighter extra)
+        assertThat(service.preview(pc("Wizard", 3, 14, 18, 18)).asiDue()).isTrue();   // -> 4
+        assertThat(service.preview(pc("Wizard", 5, 14, 30, 30)).asiDue()).isFalse();  // -> 6 (not Fighter)
+        assertThat(service.preview(pc("Rogue", 9, 14, 60, 60)).asiDue()).isTrue();    // -> 10 (Rogue extra)
+    }
+
+    @Test
+    void applyLevelUp_asi_plus2_oneAbility() {
+        PC fighter = pc("Fighter", 3, 14, 28, 28);
+        fighter.setAbilityStr((short) 16);
+
+        service.applyLevelUp(fighter, null, java.util.Map.of("STR", 2));
+
+        assertThat(fighter.getLevel()).isEqualTo((short) 4);
+        assertThat(fighter.getAbilityStr()).isEqualTo((short) 18);
+    }
+
+    @Test
+    void applyLevelUp_asi_plus1_twoAbilities() {
+        PC fighter = pc("Fighter", 3, 14, 28, 28);
+        fighter.setAbilityStr((short) 16);
+        fighter.setAbilityDex((short) 13);
+
+        service.applyLevelUp(fighter, null, java.util.Map.of("STR", 1, "DEX", 1));
+
+        assertThat(fighter.getAbilityStr()).isEqualTo((short) 17);
+        assertThat(fighter.getAbilityDex()).isEqualTo((short) 14);
+    }
+
+    @Test
+    void applyLevelUp_asi_conIncrease_grantsRetroactiveHp() {
+        // Fighter 3 -> 4, CON 15 (+2) -> 17 (+3). d10 avg 6 + new CON 3 = 9 this level;
+        // retroactive (4-1) * 1 = 3 for the prior levels; total +12.
+        PC fighter = pc("Fighter", 3, 15, 28, 28);
+
+        service.applyLevelUp(fighter, null, java.util.Map.of("CON", 2));
+
+        assertThat(fighter.getAbilityCon()).isEqualTo((short) 17);
+        assertThat(fighter.getHpMax()).isEqualTo((short) 40);
+        assertThat(fighter.getHpCurrent()).isEqualTo((short) 40);
+    }
+
+    @Test
+    void applyLevelUp_asi_requiredAtAsiLevel() {
+        PC fighter = pc("Fighter", 3, 14, 28, 28);
+        assertThatThrownBy(() -> service.applyLevelUp(fighter, null, null))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(400));
+    }
+
+    @Test
+    void applyLevelUp_asi_rejectedWhenNotAnAsiLevel() {
+        PC fighter = pc("Fighter", 4, 14, 38, 38); // -> 5, not an ASI level
+        assertThatThrownBy(() -> service.applyLevelUp(fighter, null, java.util.Map.of("STR", 2)))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(400));
+    }
+
+    @Test
+    void applyLevelUp_asi_rejectsWrongTotal() {
+        PC fighter = pc("Fighter", 3, 14, 28, 28);
+        assertThatThrownBy(() -> service.applyLevelUp(fighter, null, java.util.Map.of("STR", 1)))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(400));
+    }
+
+    @Test
+    void applyLevelUp_asi_rejectsExceeding20() {
+        PC fighter = pc("Fighter", 3, 14, 28, 28);
+        fighter.setAbilityStr((short) 19);
+        assertThatThrownBy(() -> service.applyLevelUp(fighter, null, java.util.Map.of("STR", 2)))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(400));
+    }
+
+    @Test
+    void applyLevelUp_asi_rejectsUnknownAbility() {
+        PC fighter = pc("Fighter", 3, 14, 28, 28);
+        assertThatThrownBy(() -> service.applyLevelUp(fighter, null, java.util.Map.of("LUCK", 2)))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(400));
     }
 }

--- a/src/test/java/com/moo/charactermanagerservice/services/PCServiceTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/services/PCServiceTest.java
@@ -1,6 +1,7 @@
 package com.moo.charactermanagerservice.services;
 
 import com.moo.charactermanagerservice.dto.LevelUpPreview;
+import com.moo.charactermanagerservice.dto.LevelUpRequest;
 import com.moo.charactermanagerservice.exceptions.PCNotFoundException;
 import com.moo.charactermanagerservice.models.PC;
 import com.moo.charactermanagerservice.repositories.PCRepository;
@@ -146,18 +147,18 @@ class PCServiceTest {
         PC result = pcService.levelUpPC(1L, ownerId, null);
 
         assertThat(result).isSameAs(pc);
-        verify(levelUpService).applyLevelUp(pc, null);
+        verify(levelUpService).applyLevelUp(pc, null, null);
         verify(pcRepository).save(pc);
     }
 
     @Test
-    void levelUpPC_passesSubclassChoiceToRulesEngine() {
+    void levelUpPC_passesChoicesToRulesEngine() {
         when(pcRepository.findById(1L)).thenReturn(Optional.of(pc));
         when(pcRepository.save(pc)).thenReturn(pc);
 
-        pcService.levelUpPC(1L, ownerId, "Life Domain");
+        pcService.levelUpPC(1L, ownerId, new LevelUpRequest("Life Domain", Map.of("STR", 2)));
 
-        verify(levelUpService).applyLevelUp(pc, "Life Domain");
+        verify(levelUpService).applyLevelUp(pc, "Life Domain", Map.of("STR", 2));
     }
 
     @Test
@@ -169,7 +170,7 @@ class PCServiceTest {
                 .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value())
                         .isEqualTo(403));
 
-        verify(levelUpService, never()).applyLevelUp(any(), any());
+        verify(levelUpService, never()).applyLevelUp(any(), any(), any());
         verify(pcRepository, never()).save(any());
     }
 
@@ -177,7 +178,7 @@ class PCServiceTest {
 
     @Test
     void previewLevelUp_returnsPreview_whenOwner() {
-        LevelUpPreview preview = new LevelUpPreview(4, 5, 8, 2, 7, 39, 2, 3, Map.of(), Map.of(), false, List.of());
+        LevelUpPreview preview = new LevelUpPreview(4, 5, 8, 2, 7, 39, 2, 3, Map.of(), Map.of(), false, List.of(), false);
         when(pcRepository.findById(1L)).thenReturn(Optional.of(pc));
         when(levelUpService.preview(pc)).thenReturn(preview);
 


### PR DESCRIPTION
Adds the ASI choice at milestone levels (4/8/12/16/19, plus Fighter 6/14 and Rogue 10). Feats are deferred — they need a multi-feat model change — so ASI is the only option for now and is required at an ASI level.

- ClassProgression: ASI_LEVELS per class + isAsiLevel(), MAX_ABILITY_SCORE.
- LevelUpRequest gains abilityIncreases (ABILITY -> points). LevelUpService validates server-side (must total 2 = +2 one ability or +1 to two distinct; no score past 20; only at an ASI level) and applies it BEFORE HP so the new level's gain uses the post-ASI CON modifier. A CON-modifier increase also grants retroactive HP to every prior level (the 5e rule). LevelUpPreview gains asiDue. PCService.levelUpPC/PCController now thread the whole LevelUpRequest.

Tests: LevelUpServiceTest +9 (ASI levels incl. Fighter/Rogue, +2-one, +1-two, retroactive HP on CON, required-at-ASI-level, rejected-when-not-due, wrong total,
>20 cap, unknown ability) + controller/service plumbing. 138 tests green.