### PR TITLE
fix: remove duplicate applySubclassChoice call in level-up

### DIFF
--- a/src/main/java/com/moo/charactermanagerservice/services/LevelUpService.java
+++ b/src/main/java/com/moo/charactermanagerservice/services/LevelUpService.java
@@ -116,9 +116,6 @@ public class LevelUpService {
         // above already reflects the new modifier, so only the prior levels are added here).
         int retroactiveHp = (newLevel - 1) * (newConMod - oldConMod);
 
-        // Validate the subclass choice against the new level before mutating anything.
-        applySubclassChoice(pc, newLevel, chosenSubclass);
-
         pc.setLevel((short) newLevel);
         pc.setHpMax((short) (nz(pc.getHpMax()) + hpGained + retroactiveHp));
         pc.setHpCurrent((short) (nz(pc.getHpCurrent()) + hpGained + retroactiveHp));


### PR DESCRIPTION
applyLevelUp invoked applySubclassChoice twice. The first call applies the chosen subclass; the second then sees a now-non-blank subclass, treats the choice as "not due", and throws 400 — failing applyLevelUp_setsChosenSubclass_ whenDue and breaking the subclass path once catalog content exists. Drop the redundant second call (and its stale comment); the correctly-placed call at the top of the choices block remains. Suite back to green (138 tests).