### PR TITLE
feat: add feat selection as the ASI alternative on level-up

### DIFF
--- a/src/main/java/com/moo/charactermanagerservice/dto/LevelUpPreview.java
+++ b/src/main/java/com/moo/charactermanagerservice/dto/LevelUpPreview.java
@@ -26,5 +26,6 @@ public record LevelUpPreview(
         Map<Integer, Integer> newSpellSlots,
         boolean subclassDue,
         List<String> subclassOptions,
-        boolean asiDue
+        boolean asiDue,
+        List<String> featOptions
 ) {}

--- a/src/main/java/com/moo/charactermanagerservice/dto/LevelUpRequest.java
+++ b/src/main/java/com/moo/charactermanagerservice/dto/LevelUpRequest.java
@@ -9,6 +9,8 @@ import java.util.Map;
  * <p>Phase 3: {@code subclass} (the chosen subclass name when a class reaches its
  * subclass-selection level). Phase 4: {@code abilityIncreases} — the Ability Score Improvement
  * allocation as {@code ABILITY -> points}, e.g. {@code {"CON":2}} or {@code {"STR":1,"DEX":1}}.
- * Later phases extend this (feats, spell selections) rather than widening the URL.
+ * Feats: {@code feat} — the chosen General feat name, the alternative to an ASI at an ASI level
+ * (exactly one of {@code abilityIncreases} / {@code feat} is supplied there). Later phases extend
+ * this (spell selections) rather than widening the URL.
  */
-public record LevelUpRequest(String subclass, Map<String, Integer> abilityIncreases) {}
+public record LevelUpRequest(String subclass, Map<String, Integer> abilityIncreases, String feat) {}

--- a/src/main/java/com/moo/charactermanagerservice/progression/FeatCatalog.java
+++ b/src/main/java/com/moo/charactermanagerservice/progression/FeatCatalog.java
@@ -1,0 +1,45 @@
+package com.moo.charactermanagerservice.progression;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Selectable General feats (D&D 5e 2024) — the feat option at an Ability Score Improvement level.
+ *
+ * <p>This is the server-authoritative source of truth for <em>which</em> feats may be chosen on
+ * level-up; it holds names only. Descriptions are presentation and live in the frontend. The list
+ * is a curated subset of the 2024 General feats, not exhaustive — add names here to expand it.
+ *
+ * <p>Origin feats (Alert, Tough, Lucky, Magic Initiate, …) are deliberately excluded: those are
+ * granted at level 1 by a background, not chosen at an ASI level.
+ */
+public final class FeatCatalog {
+
+    private FeatCatalog() {}
+
+    private static final Set<String> GENERAL_FEATS = Set.of(
+            "Great Weapon Master",
+            "Sharpshooter",
+            "Sentinel",
+            "War Caster",
+            "Resilient",
+            "Speedy",
+            "Mage Slayer",
+            "Polearm Master",
+            "Inspiring Leader",
+            "Skill Expert"
+    );
+
+    /** Selectable feat names, sorted for a stable preview/UI ordering. */
+    public static List<String> generalFeats() {
+        return GENERAL_FEATS.stream().sorted().collect(Collectors.toList());
+    }
+
+    /** Whether the given name is a selectable General feat (case-insensitive). */
+    public static boolean isValidFeat(String name) {
+        if (name == null) return false;
+        String trimmed = name.trim();
+        return GENERAL_FEATS.stream().anyMatch(f -> f.equalsIgnoreCase(trimmed));
+    }
+}

--- a/src/main/java/com/moo/charactermanagerservice/services/LevelUpService.java
+++ b/src/main/java/com/moo/charactermanagerservice/services/LevelUpService.java
@@ -6,10 +6,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moo.charactermanagerservice.dto.LevelUpPreview;
 import com.moo.charactermanagerservice.models.PC;
 import com.moo.charactermanagerservice.progression.ClassProgression;
+import com.moo.charactermanagerservice.progression.FeatCatalog;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +60,7 @@ public class LevelUpService {
         int hitDie = ClassProgression.hitDie(pc.getClazz());
         int conMod = ClassProgression.abilityModifier(nz(pc.getAbilityCon()));
         int hpGained = hpGain(hitDie, conMod);
+        boolean asiDue = ClassProgression.isAsiLevel(pc.getClazz(), newLevel);
 
         return new LevelUpPreview(
                 currentLevel,
@@ -72,24 +75,31 @@ public class LevelUpService {
                 ClassProgression.spellSlotsFor(pc.getClazz(), newLevel),
                 subclassDue(pc, newLevel),
                 ClassProgression.subclassesFor(pc.getClazz()),
-                ClassProgression.isAsiLevel(pc.getClazz(), newLevel)
+                asiDue,
+                asiDue ? FeatCatalog.generalFeats() : List.of()
         );
     }
 
     /** Convenience overload for level-ups with no player choices. */
     public PC applyLevelUp(PC pc) {
-        return applyLevelUp(pc, null, null);
+        return applyLevelUp(pc, null, null, null);
     }
 
     /** Convenience overload for a subclass-only choice. */
     public PC applyLevelUp(PC pc, String chosenSubclass) {
-        return applyLevelUp(pc, chosenSubclass, null);
+        return applyLevelUp(pc, chosenSubclass, null, null);
+    }
+
+    /** Convenience overload for a subclass + ASI choice (no feat). */
+    public PC applyLevelUp(PC pc, String chosenSubclass, Map<String, Integer> abilityIncreases) {
+        return applyLevelUp(pc, chosenSubclass, abilityIncreases, null);
     }
 
     /**
      * Mutate the given (managed) PC in place to its next level: validate and apply the player's
-     * choices (subclass, Ability Score Improvement), then bump level, add HP, recompute the
-     * proficiency bonus, and rebuild the spell-slot map (for casters). The caller persists.
+     * choices (subclass, and at an ASI level exactly one of an Ability Score Improvement or a
+     * feat), then bump level, add HP, recompute the proficiency bonus, and rebuild the spell-slot
+     * map (for casters). The caller persists.
      *
      * <p>HP order matters: ability scores are applied <em>before</em> HP, so the new level's gain
      * uses the post-ASI CON modifier, and a CON-modifier increase additionally grants HP to every
@@ -97,17 +107,19 @@ public class LevelUpService {
      *
      * @param chosenSubclass   the player's subclass selection, or {@code null} when none applies
      * @param abilityIncreases the ASI allocation ({@code ABILITY -> points}), or {@code null}
+     * @param chosenFeat       the chosen General feat (the ASI alternative), or {@code null}
      */
-    public PC applyLevelUp(PC pc, String chosenSubclass, Map<String, Integer> abilityIncreases) {
+    public PC applyLevelUp(PC pc, String chosenSubclass, Map<String, Integer> abilityIncreases,
+                           String chosenFeat) {
         int currentLevel = currentLevel(pc);
         assertCanLevelUp(currentLevel);
         int newLevel = currentLevel + 1;
 
         int oldConMod = ClassProgression.abilityModifier(nz(pc.getAbilityCon()));
 
-        // Validate + apply choices first — the ASI can change ability scores (including CON).
+        // Validate + apply choices first — an ASI can change ability scores (including CON).
         applySubclassChoice(pc, newLevel, chosenSubclass);
-        applyAbilityScoreImprovement(pc, newLevel, abilityIncreases);
+        applyMilestoneChoice(pc, newLevel, abilityIncreases, chosenFeat);
 
         int newConMod = ClassProgression.abilityModifier(nz(pc.getAbilityCon()));
         int hitDie = ClassProgression.hitDie(pc.getClazz());
@@ -185,32 +197,47 @@ public class LevelUpService {
         return s == null || s.isBlank();
     }
 
-    // ── Ability Score Improvement (Phase 4) ──────────────────────────────────────
+    // ── ASI-or-feat milestone choice (Phase 4 + feats) ───────────────────────────
 
     private static final List<String> ABILITIES = List.of("STR", "DEX", "CON", "INT", "WIS", "CHA");
 
     /**
-     * Validate and apply the ASI allocation. Server-authoritative: an allocation is accepted only
-     * at an ASI level, must add exactly 2 points (+2 to one ability or +1 to two distinct ones),
-     * and may not push any score past {@value ClassProgression#MAX_ABILITY_SCORE}. A choice is
-     * required at an ASI level (feats are deferred, so ASI is the only option for now).
+     * At an ASI level the player takes exactly one of an Ability Score Improvement or a General
+     * feat; at any other level neither is allowed. Server-authoritative gating; the chosen branch
+     * then validates and applies itself.
      */
-    private void applyAbilityScoreImprovement(PC pc, int newLevel, Map<String, Integer> increases) {
-        boolean due = ClassProgression.isAsiLevel(pc.getClazz(), newLevel);
-        boolean provided = increases != null && !increases.isEmpty();
+    private void applyMilestoneChoice(PC pc, int newLevel, Map<String, Integer> increases, String feat) {
+        boolean asiLevel = ClassProgression.isAsiLevel(pc.getClazz(), newLevel);
+        boolean hasAsi = increases != null && !increases.isEmpty();
+        boolean hasFeat = feat != null && !feat.isBlank();
 
-        if (!provided) {
-            if (due) {
+        if (!asiLevel) {
+            if (hasAsi || hasFeat) {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-                        "An ability score improvement is required at level " + newLevel);
+                        "No ability score improvement or feat is available at level " + newLevel);
             }
             return;
         }
-        if (!due) {
+        if (hasAsi && hasFeat) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
-                    "An ability score improvement cannot be applied at level " + newLevel);
+                    "Choose either an ability score improvement or a feat, not both");
         }
+        if (!hasAsi && !hasFeat) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "An ability score improvement or feat is required at level " + newLevel);
+        }
+        if (hasAsi) {
+            applyAsiAllocation(pc, increases);
+        } else {
+            applyFeatChoice(pc, newLevel, feat);
+        }
+    }
 
+    /**
+     * Validate and apply an ASI allocation: exactly 2 points (+2 to one ability or +1 to two
+     * distinct ones), no score past {@value ClassProgression#MAX_ABILITY_SCORE}.
+     */
+    private void applyAsiAllocation(PC pc, Map<String, Integer> increases) {
         // Normalize keys and total the points.
         Map<String, Integer> allocation = new LinkedHashMap<>();
         int total = 0;
@@ -241,6 +268,37 @@ public class LevelUpService {
         });
         allocation.forEach((ability, points) ->
                 setAbilityScore(pc, ability, (short) (abilityScore(pc, ability) + points)));
+    }
+
+    /** Validate the chosen feat against the catalog and record it among the PC's features. */
+    private void applyFeatChoice(PC pc, int newLevel, String feat) {
+        String name = feat.trim();
+        if (!FeatCatalog.isValidFeat(name)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "'" + name + "' is not a selectable feat");
+        }
+        List<Map<String, Object>> features = parseFeatures(pc.getFeatures());
+        Map<String, Object> entry = new LinkedHashMap<>();
+        entry.put("name", name);
+        entry.put("source", "Feat (Level " + newLevel + ")");
+        entry.put("desc", ""); // descriptions are presentation; the SPA supplies them by name
+        features.add(entry);
+        try {
+            pc.setFeatures(objectMapper.writeValueAsString(features));
+        } catch (JsonProcessingException ex) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to serialize features");
+        }
+    }
+
+    /** Parse the features TEXT column into a mutable list; defensive about null/blank/malformed. */
+    private List<Map<String, Object>> parseFeatures(String json) {
+        if (json == null || json.isBlank()) return new ArrayList<>();
+        try {
+            List<Map<String, Object>> parsed = objectMapper.readValue(json, new TypeReference<>() {});
+            return parsed == null ? new ArrayList<>() : new ArrayList<>(parsed);
+        } catch (JsonProcessingException e) {
+            return new ArrayList<>();
+        }
     }
 
     private int abilityScore(PC pc, String ability) {

--- a/src/main/java/com/moo/charactermanagerservice/services/PCService.java
+++ b/src/main/java/com/moo/charactermanagerservice/services/PCService.java
@@ -75,7 +75,8 @@ public class PCService {
         PC pc = findPCByIdForUser(id, userId);
         String subclass = request == null ? null : request.subclass();
         Map<String, Integer> abilityIncreases = request == null ? null : request.abilityIncreases();
-        levelUpService.applyLevelUp(pc, subclass, abilityIncreases);
+        String feat = request == null ? null : request.feat();
+        levelUpService.applyLevelUp(pc, subclass, abilityIncreases, feat);
         return pcRepository.save(pc);
     }
 

--- a/src/test/java/com/moo/charactermanagerservice/controllers/PCControllerTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/controllers/PCControllerTest.java
@@ -173,7 +173,7 @@ class PCControllerTest {
 
     @Test
     void previewLevelUp_returns200_withPreview() {
-        LevelUpPreview preview = new LevelUpPreview(4, 5, 10, 3, 9, 39, 2, 3, Map.of(), Map.of(), false, List.of(), false);
+        LevelUpPreview preview = new LevelUpPreview(4, 5, 10, 3, 9, 39, 2, 3, Map.of(), Map.of(), false, List.of(), false, List.of());
         when(pcService.previewLevelUp(1L, ownerId)).thenReturn(preview);
 
         ResponseEntity<LevelUpPreview> response = pcController.previewLevelUp(1L, auth);
@@ -206,7 +206,7 @@ class PCControllerTest {
 
     @Test
     void levelUp_passesChoicesFromBody() {
-        LevelUpRequest body = new LevelUpRequest("Life Domain", java.util.Map.of("STR", 2));
+        LevelUpRequest body = new LevelUpRequest("Life Domain", java.util.Map.of("STR", 2), null);
         when(pcService.levelUpPC(1L, ownerId, body)).thenReturn(pc);
 
         pcController.levelUp(1L, auth, body);

--- a/src/test/java/com/moo/charactermanagerservice/services/LevelUpServiceTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/services/LevelUpServiceTest.java
@@ -365,4 +365,58 @@ class LevelUpServiceTest {
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(400));
     }
+
+    // --- Feats (the ASI alternative) ---
+
+    @Test
+    void preview_featOptions_offeredOnlyAtAsiLevels() {
+        assertThat(service.preview(pc("Fighter", 3, 14, 28, 28)).featOptions()).isNotEmpty(); // -> 4
+        assertThat(service.preview(pc("Fighter", 4, 14, 38, 38)).featOptions()).isEmpty();    // -> 5
+    }
+
+    @Test
+    void applyLevelUp_feat_recordedAmongFeatures_andNoAsiApplied() {
+        PC fighter = pc("Fighter", 3, 14, 28, 28);
+        fighter.setAbilityStr((short) 16);
+
+        service.applyLevelUp(fighter, null, null, "Sentinel");
+
+        assertThat(fighter.getLevel()).isEqualTo((short) 4);
+        assertThat(fighter.getAbilityStr()).isEqualTo((short) 16); // unchanged — feat, not ASI
+        assertThat(fighter.getFeatures()).contains("Sentinel").contains("Feat (Level 4)");
+    }
+
+    @Test
+    void applyLevelUp_feat_appendsToExistingFeatures() {
+        PC fighter = pc("Fighter", 3, 14, 28, 28);
+        fighter.setFeatures("[{\"name\":\"Second Wind\",\"source\":\"Fighter 1\",\"desc\":\"Regain HP\"}]");
+
+        service.applyLevelUp(fighter, null, null, "Great Weapon Master");
+
+        assertThat(fighter.getFeatures()).contains("Second Wind").contains("Great Weapon Master");
+    }
+
+    @Test
+    void applyLevelUp_feat_rejectsUnknownFeat() {
+        PC fighter = pc("Fighter", 3, 14, 28, 28);
+        assertThatThrownBy(() -> service.applyLevelUp(fighter, null, null, "Superman"))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(400));
+    }
+
+    @Test
+    void applyLevelUp_feat_rejectsBothAsiAndFeat() {
+        PC fighter = pc("Fighter", 3, 14, 28, 28);
+        assertThatThrownBy(() -> service.applyLevelUp(fighter, null, java.util.Map.of("STR", 2), "Sentinel"))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(400));
+    }
+
+    @Test
+    void applyLevelUp_feat_rejectedWhenNotAnAsiLevel() {
+        PC fighter = pc("Fighter", 4, 14, 38, 38); // -> 5, not an ASI level
+        assertThatThrownBy(() -> service.applyLevelUp(fighter, null, null, "Sentinel"))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(400));
+    }
 }

--- a/src/test/java/com/moo/charactermanagerservice/services/PCServiceTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/services/PCServiceTest.java
@@ -147,7 +147,7 @@ class PCServiceTest {
         PC result = pcService.levelUpPC(1L, ownerId, null);
 
         assertThat(result).isSameAs(pc);
-        verify(levelUpService).applyLevelUp(pc, null, null);
+        verify(levelUpService).applyLevelUp(pc, null, null, null);
         verify(pcRepository).save(pc);
     }
 
@@ -156,9 +156,9 @@ class PCServiceTest {
         when(pcRepository.findById(1L)).thenReturn(Optional.of(pc));
         when(pcRepository.save(pc)).thenReturn(pc);
 
-        pcService.levelUpPC(1L, ownerId, new LevelUpRequest("Life Domain", Map.of("STR", 2)));
+        pcService.levelUpPC(1L, ownerId, new LevelUpRequest("Life Domain", Map.of("STR", 2), "Sentinel"));
 
-        verify(levelUpService).applyLevelUp(pc, "Life Domain", Map.of("STR", 2));
+        verify(levelUpService).applyLevelUp(pc, "Life Domain", Map.of("STR", 2), "Sentinel");
     }
 
     @Test
@@ -170,7 +170,7 @@ class PCServiceTest {
                 .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value())
                         .isEqualTo(403));
 
-        verify(levelUpService, never()).applyLevelUp(any(), any(), any());
+        verify(levelUpService, never()).applyLevelUp(any(), any(), any(), any());
         verify(pcRepository, never()).save(any());
     }
 
@@ -178,7 +178,7 @@ class PCServiceTest {
 
     @Test
     void previewLevelUp_returnsPreview_whenOwner() {
-        LevelUpPreview preview = new LevelUpPreview(4, 5, 8, 2, 7, 39, 2, 3, Map.of(), Map.of(), false, List.of(), false);
+        LevelUpPreview preview = new LevelUpPreview(4, 5, 8, 2, 7, 39, 2, 3, Map.of(), Map.of(), false, List.of(), false, List.of());
         when(pcRepository.findById(1L)).thenReturn(Optional.of(pc));
         when(levelUpService.preview(pc)).thenReturn(preview);
 


### PR DESCRIPTION
Completes the milestone choice: at an ASI level the player now takes EITHER an Ability Score Improvement OR a General feat (previously ASI was forced). The server enforces exactly one of the two at an ASI level, and neither elsewhere.

- New progression/FeatCatalog: a curated set of 2024 General feats (names only — the authoritative list of selectable feats; descriptions are presentation and live in the frontend). Origin feats are excluded (those are level-1 grants).
- LevelUpRequest gains `feat`. LevelUpService.applyMilestoneChoice replaces the forced-ASI logic with the ASI-xor-feat rule; a chosen feat is validated against the catalog and recorded in the PC's `features` JSON as {name, source:"Feat (Level N)", desc:""} (no schema change). LevelUpPreview gains `featOptions` (the catalog, non-empty only at ASI levels).
- PCService threads request.feat() through.

Tests: LevelUpServiceTest +6 (feat recorded, appended to existing features, unknown-feat rejected, both-ASI-and-feat rejected, feat-at-non-ASI-level rejected, featOptions gating) + controller/service plumbing. 144 tests green.