### PR TITLE
feat: auto-grant class features on level-up

### DIFF
--- a/src/main/java/com/moo/charactermanagerservice/dto/FeatureGain.java
+++ b/src/main/java/com/moo/charactermanagerservice/dto/FeatureGain.java
@@ -1,0 +1,8 @@
+package com.moo.charactermanagerservice.dto;
+
+/**
+ * A single class feature gained at a level — name plus a short description. Surfaced in the
+ * level-up preview and recorded among the PC's features on commit. Content is server-owned
+ * (unlike feats, whose descriptions are presentation-only), so the description travels with it.
+ */
+public record FeatureGain(String name, String desc) {}

--- a/src/main/java/com/moo/charactermanagerservice/dto/LevelUpPreview.java
+++ b/src/main/java/com/moo/charactermanagerservice/dto/LevelUpPreview.java
@@ -27,5 +27,6 @@ public record LevelUpPreview(
         boolean subclassDue,
         List<String> subclassOptions,
         boolean asiDue,
-        List<String> featOptions
+        List<String> featOptions,
+        List<FeatureGain> featuresGained
 ) {}

--- a/src/main/java/com/moo/charactermanagerservice/progression/ClassFeatures.java
+++ b/src/main/java/com/moo/charactermanagerservice/progression/ClassFeatures.java
@@ -1,0 +1,61 @@
+package com.moo.charactermanagerservice.progression;
+
+import com.moo.charactermanagerservice.dto.FeatureGain;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Class features granted automatically on level-up (D&D 5e 2024), keyed by class then by the
+ * level at which they are gained. Server-authoritative and server-owned (names and descriptions
+ * both live here, unlike feats whose descriptions are presentation).
+ *
+ * <p>This is a <strong>curated, extensible seed</strong> — like {@link FeatCatalog} it is not
+ * exhaustive. Barbarian and Fighter are filled in for the lower levels as worked examples; other
+ * classes and higher levels return no features until their entries are added here. Level 1
+ * features are intentionally absent: those are granted at character creation, not on level-up.
+ * Subclass features are out of scope (the subclass catalog is the seam for those).
+ */
+public final class ClassFeatures {
+
+    private ClassFeatures() {}
+
+    private static final Map<String, Map<Integer, List<FeatureGain>>> FEATURES = Map.of(
+            "barbarian", Map.of(
+                    2, List.of(
+                            new FeatureGain("Reckless Attack",
+                                    "On your first attack of your turn you can attack with advantage; attack rolls against you have advantage until your next turn."),
+                            new FeatureGain("Danger Sense",
+                                    "You have advantage on Dexterity saving throws against effects you can see, such as traps and spells.")),
+                    3, List.of(
+                            new FeatureGain("Primal Knowledge",
+                                    "You gain an additional skill proficiency, and can channel your rage into certain ability checks.")),
+                    5, List.of(
+                            new FeatureGain("Extra Attack",
+                                    "You can attack twice, instead of once, whenever you take the Attack action on your turn."),
+                            new FeatureGain("Fast Movement",
+                                    "Your speed increases by 10 feet while you aren't wearing heavy armor."))
+            ),
+            "fighter", Map.of(
+                    2, List.of(
+                            new FeatureGain("Action Surge",
+                                    "Once per short or long rest, you can take one additional action on your turn.")),
+                    3, List.of(
+                            new FeatureGain("Tactical Mind",
+                                    "When you fail an ability check you can expend a use of Second Wind to add 1d10 to it.")),
+                    5, List.of(
+                            new FeatureGain("Extra Attack",
+                                    "You can attack twice, instead of once, whenever you take the Attack action on your turn."),
+                            new FeatureGain("Tactical Shift",
+                                    "When you activate Second Wind, you can move up to half your speed without provoking opportunity attacks."))
+            )
+    );
+
+    /** Features gained by a class at a specific level; empty when none are seeded. */
+    public static List<FeatureGain> featuresAt(String clazz, int level) {
+        if (clazz == null) return List.of();
+        Map<Integer, List<FeatureGain>> byLevel = FEATURES.get(clazz.trim().toLowerCase());
+        if (byLevel == null) return List.of();
+        return byLevel.getOrDefault(level, List.of());
+    }
+}

--- a/src/main/java/com/moo/charactermanagerservice/services/LevelUpService.java
+++ b/src/main/java/com/moo/charactermanagerservice/services/LevelUpService.java
@@ -3,8 +3,10 @@ package com.moo.charactermanagerservice.services;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moo.charactermanagerservice.dto.FeatureGain;
 import com.moo.charactermanagerservice.dto.LevelUpPreview;
 import com.moo.charactermanagerservice.models.PC;
+import com.moo.charactermanagerservice.progression.ClassFeatures;
 import com.moo.charactermanagerservice.progression.ClassProgression;
 import com.moo.charactermanagerservice.progression.FeatCatalog;
 import org.springframework.http.HttpStatus;
@@ -76,7 +78,8 @@ public class LevelUpService {
                 subclassDue(pc, newLevel),
                 ClassProgression.subclassesFor(pc.getClazz()),
                 asiDue,
-                asiDue ? FeatCatalog.generalFeats() : List.of()
+                asiDue ? FeatCatalog.generalFeats() : List.of(),
+                ClassFeatures.featuresAt(pc.getClazz(), newLevel)
         );
     }
 
@@ -120,6 +123,7 @@ public class LevelUpService {
         // Validate + apply choices first — an ASI can change ability scores (including CON).
         applySubclassChoice(pc, newLevel, chosenSubclass);
         applyMilestoneChoice(pc, newLevel, abilityIncreases, chosenFeat);
+        grantClassFeatures(pc, newLevel);
 
         int newConMod = ClassProgression.abilityModifier(nz(pc.getAbilityCon()));
         int hitDie = ClassProgression.hitDie(pc.getClazz());
@@ -278,16 +282,28 @@ public class LevelUpService {
                     "'" + name + "' is not a selectable feat");
         }
         List<Map<String, Object>> features = parseFeatures(pc.getFeatures());
+        features.add(featureEntry(name, "Feat (Level " + newLevel + ")", ""));
+        pc.setFeatures(writeFeatures(features));
+    }
+
+    /** Append the class features (if any) gained at the new level to the PC's features list. */
+    private void grantClassFeatures(PC pc, int newLevel) {
+        List<FeatureGain> gained = ClassFeatures.featuresAt(pc.getClazz(), newLevel);
+        if (gained.isEmpty()) return;
+        List<Map<String, Object>> features = parseFeatures(pc.getFeatures());
+        String source = pc.getClazz() + " " + newLevel;
+        for (FeatureGain g : gained) {
+            features.add(featureEntry(g.name(), source, g.desc()));
+        }
+        pc.setFeatures(writeFeatures(features));
+    }
+
+    private Map<String, Object> featureEntry(String name, String source, String desc) {
         Map<String, Object> entry = new LinkedHashMap<>();
         entry.put("name", name);
-        entry.put("source", "Feat (Level " + newLevel + ")");
-        entry.put("desc", ""); // descriptions are presentation; the SPA supplies them by name
-        features.add(entry);
-        try {
-            pc.setFeatures(objectMapper.writeValueAsString(features));
-        } catch (JsonProcessingException ex) {
-            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to serialize features");
-        }
+        entry.put("source", source);
+        entry.put("desc", desc);
+        return entry;
     }
 
     /** Parse the features TEXT column into a mutable list; defensive about null/blank/malformed. */
@@ -298,6 +314,14 @@ public class LevelUpService {
             return parsed == null ? new ArrayList<>() : new ArrayList<>(parsed);
         } catch (JsonProcessingException e) {
             return new ArrayList<>();
+        }
+    }
+
+    private String writeFeatures(List<Map<String, Object>> features) {
+        try {
+            return objectMapper.writeValueAsString(features);
+        } catch (JsonProcessingException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to serialize features");
         }
     }
 

--- a/src/test/java/com/moo/charactermanagerservice/controllers/PCControllerTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/controllers/PCControllerTest.java
@@ -173,7 +173,7 @@ class PCControllerTest {
 
     @Test
     void previewLevelUp_returns200_withPreview() {
-        LevelUpPreview preview = new LevelUpPreview(4, 5, 10, 3, 9, 39, 2, 3, Map.of(), Map.of(), false, List.of(), false, List.of());
+        LevelUpPreview preview = new LevelUpPreview(4, 5, 10, 3, 9, 39, 2, 3, Map.of(), Map.of(), false, List.of(), false, List.of(), List.of());
         when(pcService.previewLevelUp(1L, ownerId)).thenReturn(preview);
 
         ResponseEntity<LevelUpPreview> response = pcController.previewLevelUp(1L, auth);

--- a/src/test/java/com/moo/charactermanagerservice/services/LevelUpServiceTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/services/LevelUpServiceTest.java
@@ -1,10 +1,13 @@
 package com.moo.charactermanagerservice.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moo.charactermanagerservice.dto.FeatureGain;
 import com.moo.charactermanagerservice.dto.LevelUpPreview;
 import com.moo.charactermanagerservice.models.PC;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -418,5 +421,51 @@ class LevelUpServiceTest {
         assertThatThrownBy(() -> service.applyLevelUp(fighter, null, null, "Sentinel"))
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(400));
+    }
+
+    // --- Auto-granted class features ---
+
+    @Test
+    void preview_featuresGained_atSeededLevel() {
+        // Barbarian 1 -> 2 grants Reckless Attack + Danger Sense (seeded).
+        List<String> names = service.preview(pc("Barbarian", 1, 14, 14, 14)).featuresGained()
+                .stream().map(FeatureGain::name).toList();
+        assertThat(names).contains("Reckless Attack", "Danger Sense");
+    }
+
+    @Test
+    void preview_featuresGained_emptyForUnseededClassOrLevel() {
+        assertThat(service.preview(pc("Wizard", 1, 14, 8, 8)).featuresGained()).isEmpty();   // Wizard not seeded
+        assertThat(service.preview(pc("Barbarian", 5, 14, 50, 50)).featuresGained()).isEmpty(); // -> 6 not seeded
+    }
+
+    @Test
+    void applyLevelUp_grantsClassFeatures_taggedWithClassAndLevel() {
+        PC barbarian = pc("Barbarian", 1, 14, 14, 14);
+
+        service.applyLevelUp(barbarian);
+
+        assertThat(barbarian.getLevel()).isEqualTo((short) 2);
+        assertThat(barbarian.getFeatures()).contains("Reckless Attack").contains("Barbarian 2");
+    }
+
+    @Test
+    void applyLevelUp_appendsFeaturesToExisting() {
+        PC barbarian = pc("Barbarian", 1, 14, 14, 14);
+        barbarian.setFeatures("[{\"name\":\"Rage\",\"source\":\"Barbarian 1\",\"desc\":\"...\"}]");
+
+        service.applyLevelUp(barbarian);
+
+        assertThat(barbarian.getFeatures()).contains("Rage").contains("Reckless Attack");
+    }
+
+    @Test
+    void applyLevelUp_unseededClass_leavesFeaturesUntouched() {
+        PC wizard = pc("Wizard", 1, 14, 8, 8); // -> 2, not seeded
+        wizard.setFeatures("[]");
+
+        service.applyLevelUp(wizard);
+
+        assertThat(wizard.getFeatures()).isEqualTo("[]");
     }
 }

--- a/src/test/java/com/moo/charactermanagerservice/services/PCServiceTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/services/PCServiceTest.java
@@ -178,7 +178,7 @@ class PCServiceTest {
 
     @Test
     void previewLevelUp_returnsPreview_whenOwner() {
-        LevelUpPreview preview = new LevelUpPreview(4, 5, 8, 2, 7, 39, 2, 3, Map.of(), Map.of(), false, List.of(), false, List.of());
+        LevelUpPreview preview = new LevelUpPreview(4, 5, 8, 2, 7, 39, 2, 3, Map.of(), Map.of(), false, List.of(), false, List.of(), List.of());
         when(pcRepository.findById(1L)).thenReturn(Optional.of(pc));
         when(levelUpService.preview(pc)).thenReturn(preview);
 


### PR DESCRIPTION
Leveling up now appends the class features gained at the new level to the character's features list, shown in the modal before commit.

- New progression/ClassFeatures: a curated, extensible catalog of class features by class and level (Barbarian and Fighter seeded for lower levels as worked examples; other classes/levels grant nothing until added). Server-owned content — names AND descriptions live here, unlike feats. Level 1 and subclass features are intentionally out of scope (creation / the subclass seam).
- New dto/FeatureGain (name + desc). LevelUpService.grantClassFeatures appends featuresAt(class, newLevel) to the features JSON, tagged source "<Class> N", reusing the same parse/append helper as feats. LevelUpPreview gains featuresGained so the SPA can show what's granted.

Tests: LevelUpServiceTest +5 (preview lists seeded features, empty for unseeded class/level, applied + tagged, appended to existing, unseeded left untouched). 149 tests green.