### PR TITLE
feat: show cantrips-known progression in level-up preview

### DIFF
--- a/src/main/java/com/moo/charactermanagerservice/dto/LevelUpPreview.java
+++ b/src/main/java/com/moo/charactermanagerservice/dto/LevelUpPreview.java
@@ -28,5 +28,7 @@ public record LevelUpPreview(
         List<String> subclassOptions,
         boolean asiDue,
         List<String> featOptions,
-        List<FeatureGain> featuresGained
+        List<FeatureGain> featuresGained,
+        int currentCantripsKnown,
+        int newCantripsKnown
 ) {}

--- a/src/main/java/com/moo/charactermanagerservice/progression/ClassProgression.java
+++ b/src/main/java/com/moo/charactermanagerservice/progression/ClassProgression.java
@@ -140,6 +140,22 @@ public final class ClassProgression {
             { 5, 4 }, // L20
     };
 
+    /** Cantrips known at level 1 per caster class (2024 PHB); absent classes know none. */
+    private static final Map<String, Integer> BASE_CANTRIPS = Map.of(
+            "bard", 2, "cleric", 3, "druid", 2, "sorcerer", 4, "warlock", 2, "wizard", 3
+    );
+
+    /**
+     * Cantrips known at the given level: the class base plus the standard increases at levels
+     * 4 and 10. Returns 0 for non-casters / classes that don't learn cantrips.
+     */
+    public static int cantripsKnownFor(String clazz, int level) {
+        if (clazz == null || level < 1) return 0;
+        Integer base = BASE_CANTRIPS.get(clazz.trim().toLowerCase());
+        if (base == null) return 0;
+        return base + (level >= 4 ? 1 : 0) + (level >= 10 ? 1 : 0);
+    }
+
     /** True when the class is one the app treats as a spellcaster (full or pact). */
     public static boolean isCaster(String clazz) {
         if (clazz == null) return false;

--- a/src/main/java/com/moo/charactermanagerservice/services/LevelUpService.java
+++ b/src/main/java/com/moo/charactermanagerservice/services/LevelUpService.java
@@ -79,7 +79,9 @@ public class LevelUpService {
                 ClassProgression.subclassesFor(pc.getClazz()),
                 asiDue,
                 asiDue ? FeatCatalog.generalFeats() : List.of(),
-                ClassFeatures.featuresAt(pc.getClazz(), newLevel)
+                ClassFeatures.featuresAt(pc.getClazz(), newLevel),
+                ClassProgression.cantripsKnownFor(pc.getClazz(), currentLevel),
+                ClassProgression.cantripsKnownFor(pc.getClazz(), newLevel)
         );
     }
 

--- a/src/test/java/com/moo/charactermanagerservice/controllers/PCControllerTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/controllers/PCControllerTest.java
@@ -173,7 +173,7 @@ class PCControllerTest {
 
     @Test
     void previewLevelUp_returns200_withPreview() {
-        LevelUpPreview preview = new LevelUpPreview(4, 5, 10, 3, 9, 39, 2, 3, Map.of(), Map.of(), false, List.of(), false, List.of(), List.of());
+        LevelUpPreview preview = new LevelUpPreview(4, 5, 10, 3, 9, 39, 2, 3, Map.of(), Map.of(), false, List.of(), false, List.of(), List.of(), 0, 0);
         when(pcService.previewLevelUp(1L, ownerId)).thenReturn(preview);
 
         ResponseEntity<LevelUpPreview> response = pcController.previewLevelUp(1L, auth);

--- a/src/test/java/com/moo/charactermanagerservice/services/LevelUpServiceTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/services/LevelUpServiceTest.java
@@ -468,4 +468,28 @@ class LevelUpServiceTest {
 
         assertThat(wizard.getFeatures()).isEqualTo("[]");
     }
+
+    // --- Cantrips-known progression (preview only) ---
+
+    @Test
+    void preview_cantripsKnown_bumpsAtLevel4() {
+        // Wizard base 3 cantrips; +1 at level 4.
+        LevelUpPreview p = service.preview(pc("Wizard", 3, 14, 18, 18)); // -> 4
+        assertThat(p.currentCantripsKnown()).isEqualTo(3);
+        assertThat(p.newCantripsKnown()).isEqualTo(4);
+    }
+
+    @Test
+    void preview_cantripsKnown_unchangedBetweenBreakpoints() {
+        LevelUpPreview p = service.preview(pc("Sorcerer", 5, 14, 32, 32)); // -> 6; sorcerer base 4, +1 at 4
+        assertThat(p.currentCantripsKnown()).isEqualTo(5);
+        assertThat(p.newCantripsKnown()).isEqualTo(5);
+    }
+
+    @Test
+    void preview_cantripsKnown_zeroForNonCaster() {
+        LevelUpPreview p = service.preview(pc("Fighter", 1, 14, 12, 12));
+        assertThat(p.currentCantripsKnown()).isEqualTo(0);
+        assertThat(p.newCantripsKnown()).isEqualTo(0);
+    }
 }

--- a/src/test/java/com/moo/charactermanagerservice/services/PCServiceTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/services/PCServiceTest.java
@@ -178,7 +178,7 @@ class PCServiceTest {
 
     @Test
     void previewLevelUp_returnsPreview_whenOwner() {
-        LevelUpPreview preview = new LevelUpPreview(4, 5, 8, 2, 7, 39, 2, 3, Map.of(), Map.of(), false, List.of(), false, List.of(), List.of());
+        LevelUpPreview preview = new LevelUpPreview(4, 5, 8, 2, 7, 39, 2, 3, Map.of(), Map.of(), false, List.of(), false, List.of(), List.of(), 0, 0);
         when(pcRepository.findById(1L)).thenReturn(Optional.of(pc));
         when(levelUpService.preview(pc)).thenReturn(preview);
 


### PR DESCRIPTION
Adds cantrips-known to the level-up preview so casters see when they learn a new cantrip. ClassProgression.cantripsKnownFor returns the class base (bard/druid/ warlock 2, wizard/cleric 3, sorcerer 4) plus the standard increases at levels 4 and 10; non-casters return 0. LevelUpPreview gains currentCantripsKnown / newCantripsKnown (informational — no PC change, mirrors the spell-slot picture).

The prepared/known-spell count tables and an in-modal spell picker remain a deferred seam (per-class counts are larger, and spell selection needs the spell list, which lives in the frontend).

Tests: LevelUpServiceTest +3 (bump at L4, unchanged between breakpoints, zero for non-casters). 152 tests green.