### PR TITLE
feat: let casters learn new spells/cantrips on level-up

### DIFF
--- a/src/main/java/com/moo/charactermanagerservice/dto/LevelUpPreview.java
+++ b/src/main/java/com/moo/charactermanagerservice/dto/LevelUpPreview.java
@@ -30,5 +30,7 @@ public record LevelUpPreview(
         List<String> featOptions,
         List<FeatureGain> featuresGained,
         int currentCantripsKnown,
-        int newCantripsKnown
+        int newCantripsKnown,
+        int currentSpellsKnown,
+        int newSpellsKnown
 ) {}

--- a/src/main/java/com/moo/charactermanagerservice/dto/LevelUpRequest.java
+++ b/src/main/java/com/moo/charactermanagerservice/dto/LevelUpRequest.java
@@ -1,5 +1,6 @@
 package com.moo.charactermanagerservice.dto;
 
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -10,7 +11,17 @@ import java.util.Map;
  * subclass-selection level). Phase 4: {@code abilityIncreases} — the Ability Score Improvement
  * allocation as {@code ABILITY -> points}, e.g. {@code {"CON":2}} or {@code {"STR":1,"DEX":1}}.
  * Feats: {@code feat} — the chosen General feat name, the alternative to an ASI at an ASI level
- * (exactly one of {@code abilityIncreases} / {@code feat} is supplied there). Later phases extend
- * this (spell selections) rather than widening the URL.
+ * (exactly one of {@code abilityIncreases} / {@code feat} is supplied there).
+ *
+ * <p>Spells: {@code newSpells} — cantrips/spells the caster learns this level, each a spell object
+ * ({@code lvl}, {@code name}, …) built by the SPA from its spell list. The server validates only
+ * the <em>count</em> against the level-up delta (and rejects duplicates); it does not validate
+ * individual spell names, because the spell list lives in the frontend (the backend must not
+ * depend on the external D&D API). Same trust posture as feats/subclasses.
  */
-public record LevelUpRequest(String subclass, Map<String, Integer> abilityIncreases, String feat) {}
+public record LevelUpRequest(
+        String subclass,
+        Map<String, Integer> abilityIncreases,
+        String feat,
+        List<Map<String, Object>> newSpells
+) {}

--- a/src/main/java/com/moo/charactermanagerservice/progression/ClassProgression.java
+++ b/src/main/java/com/moo/charactermanagerservice/progression/ClassProgression.java
@@ -156,6 +156,27 @@ public final class ClassProgression {
         return base + (level >= 4 ? 1 : 0) + (level >= 10 ? 1 : 0);
     }
 
+    /**
+     * Prepared/known spells by level (2024 PHB). Full casters share the standard progression;
+     * warlock uses the smaller pact table. Returns 0 for non-casters. This is the total a caster
+     * may have prepared/known at that level; the level-up delta is how many new ones they may add.
+     */
+    private static final int[] FULL_CASTER_PREPARED = {
+            4, 5, 6, 7, 9, 10, 11, 12, 14, 15, 16, 16, 17, 17, 18, 18, 19, 20, 21, 22
+    };
+    private static final int[] PACT_PREPARED = {
+            2, 3, 4, 5, 6, 7, 8, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15
+    };
+
+    public static int preparedSpellsFor(String clazz, int level) {
+        if (clazz == null || level < 1) return 0;
+        String key = clazz.trim().toLowerCase();
+        int idx = Math.min(level, MAX_LEVEL) - 1;
+        if (FULL_CASTERS.contains(key)) return FULL_CASTER_PREPARED[idx];
+        if (PACT_CASTER.equals(key)) return PACT_PREPARED[idx];
+        return 0;
+    }
+
     /** True when the class is one the app treats as a spellcaster (full or pact). */
     public static boolean isCaster(String clazz) {
         if (clazz == null) return false;

--- a/src/main/java/com/moo/charactermanagerservice/services/LevelUpService.java
+++ b/src/main/java/com/moo/charactermanagerservice/services/LevelUpService.java
@@ -81,7 +81,9 @@ public class LevelUpService {
                 asiDue ? FeatCatalog.generalFeats() : List.of(),
                 ClassFeatures.featuresAt(pc.getClazz(), newLevel),
                 ClassProgression.cantripsKnownFor(pc.getClazz(), currentLevel),
-                ClassProgression.cantripsKnownFor(pc.getClazz(), newLevel)
+                ClassProgression.cantripsKnownFor(pc.getClazz(), newLevel),
+                ClassProgression.preparedSpellsFor(pc.getClazz(), currentLevel),
+                ClassProgression.preparedSpellsFor(pc.getClazz(), newLevel)
         );
     }
 
@@ -100,11 +102,17 @@ public class LevelUpService {
         return applyLevelUp(pc, chosenSubclass, abilityIncreases, null);
     }
 
+    /** Convenience overload for subclass + ASI + feat (no new spells). */
+    public PC applyLevelUp(PC pc, String chosenSubclass, Map<String, Integer> abilityIncreases,
+                           String chosenFeat) {
+        return applyLevelUp(pc, chosenSubclass, abilityIncreases, chosenFeat, null);
+    }
+
     /**
      * Mutate the given (managed) PC in place to its next level: validate and apply the player's
-     * choices (subclass, and at an ASI level exactly one of an Ability Score Improvement or a
-     * feat), then bump level, add HP, recompute the proficiency bonus, and rebuild the spell-slot
-     * map (for casters). The caller persists.
+     * choices (subclass; at an ASI level exactly one of an Ability Score Improvement or a feat;
+     * any newly-learned spells), then bump level, add HP, recompute the proficiency bonus, and
+     * rebuild the spell-slot map (for casters). The caller persists.
      *
      * <p>HP order matters: ability scores are applied <em>before</em> HP, so the new level's gain
      * uses the post-ASI CON modifier, and a CON-modifier increase additionally grants HP to every
@@ -113,9 +121,10 @@ public class LevelUpService {
      * @param chosenSubclass   the player's subclass selection, or {@code null} when none applies
      * @param abilityIncreases the ASI allocation ({@code ABILITY -> points}), or {@code null}
      * @param chosenFeat       the chosen General feat (the ASI alternative), or {@code null}
+     * @param newSpells        cantrips/spells learned this level (count-validated), or {@code null}
      */
     public PC applyLevelUp(PC pc, String chosenSubclass, Map<String, Integer> abilityIncreases,
-                           String chosenFeat) {
+                           String chosenFeat, List<Map<String, Object>> newSpells) {
         int currentLevel = currentLevel(pc);
         assertCanLevelUp(currentLevel);
         int newLevel = currentLevel + 1;
@@ -126,6 +135,7 @@ public class LevelUpService {
         applySubclassChoice(pc, newLevel, chosenSubclass);
         applyMilestoneChoice(pc, newLevel, abilityIncreases, chosenFeat);
         grantClassFeatures(pc, newLevel);
+        applySpellChoices(pc, currentLevel, newLevel, newSpells);
 
         int newConMod = ClassProgression.abilityModifier(nz(pc.getAbilityCon()));
         int hitDie = ClassProgression.hitDie(pc.getClazz());
@@ -283,21 +293,21 @@ public class LevelUpService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                     "'" + name + "' is not a selectable feat");
         }
-        List<Map<String, Object>> features = parseFeatures(pc.getFeatures());
+        List<Map<String, Object>> features = parseObjectArray(pc.getFeatures());
         features.add(featureEntry(name, "Feat (Level " + newLevel + ")", ""));
-        pc.setFeatures(writeFeatures(features));
+        pc.setFeatures(writeObjectArray(features));
     }
 
     /** Append the class features (if any) gained at the new level to the PC's features list. */
     private void grantClassFeatures(PC pc, int newLevel) {
         List<FeatureGain> gained = ClassFeatures.featuresAt(pc.getClazz(), newLevel);
         if (gained.isEmpty()) return;
-        List<Map<String, Object>> features = parseFeatures(pc.getFeatures());
+        List<Map<String, Object>> features = parseObjectArray(pc.getFeatures());
         String source = pc.getClazz() + " " + newLevel;
         for (FeatureGain g : gained) {
             features.add(featureEntry(g.name(), source, g.desc()));
         }
-        pc.setFeatures(writeFeatures(features));
+        pc.setFeatures(writeObjectArray(features));
     }
 
     private Map<String, Object> featureEntry(String name, String source, String desc) {
@@ -308,8 +318,72 @@ public class LevelUpService {
         return entry;
     }
 
-    /** Parse the features TEXT column into a mutable list; defensive about null/blank/malformed. */
-    private List<Map<String, Object>> parseFeatures(String json) {
+    // ── Spell selection (learning new cantrips/spells) ───────────────────────────
+
+    /**
+     * Append the player's newly-learned cantrips/spells to the PC's {@code spells} list.
+     *
+     * <p>Server-authoritative on <em>count</em> only: the number of new cantrips (spell level 0)
+     * may not exceed the cantrips-known delta, and the number of new leveled spells may not exceed
+     * the prepared/known-spells delta, for this level. Duplicates (by name, case-insensitive) are
+     * rejected. Individual spell <em>names</em> are NOT validated — the spell list lives in the
+     * frontend (the backend must not depend on the external D&D API), so the client-supplied spell
+     * objects are accepted as-is. Same trust posture as feats and subclasses.
+     */
+    private void applySpellChoices(PC pc, int currentLevel, int newLevel,
+                                   List<Map<String, Object>> chosen) {
+        if (chosen == null || chosen.isEmpty()) return;
+
+        int cantripDelta = ClassProgression.cantripsKnownFor(pc.getClazz(), newLevel)
+                - ClassProgression.cantripsKnownFor(pc.getClazz(), currentLevel);
+        int spellDelta = ClassProgression.preparedSpellsFor(pc.getClazz(), newLevel)
+                - ClassProgression.preparedSpellsFor(pc.getClazz(), currentLevel);
+
+        int newCantrips = 0;
+        int newLeveled = 0;
+        for (Map<String, Object> spell : chosen) {
+            if (spellLevelOf(spell) == 0) newCantrips++;
+            else newLeveled++;
+        }
+        if (newCantrips > Math.max(0, cantripDelta)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "You can learn at most " + Math.max(0, cantripDelta) + " new cantrip(s) at level " + newLevel);
+        }
+        if (newLeveled > Math.max(0, spellDelta)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                    "You can learn at most " + Math.max(0, spellDelta) + " new spell(s) at level " + newLevel);
+        }
+
+        List<Map<String, Object>> spells = parseObjectArray(pc.getSpells());
+        java.util.Set<String> known = new java.util.HashSet<>();
+        for (Map<String, Object> existing : spells) {
+            known.add(spellName(existing).toLowerCase());
+        }
+        for (Map<String, Object> spell : chosen) {
+            String name = spellName(spell);
+            if (name.isBlank()) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Each spell must have a name");
+            }
+            if (!known.add(name.toLowerCase())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "'" + name + "' is already known");
+            }
+            spells.add(spell);
+        }
+        pc.setSpells(writeObjectArray(spells));
+    }
+
+    private int spellLevelOf(Map<String, Object> spell) {
+        Object lvl = spell.get("lvl");
+        return lvl instanceof Number n ? n.intValue() : 0;
+    }
+
+    private String spellName(Map<String, Object> spell) {
+        Object name = spell.get("name");
+        return name == null ? "" : name.toString();
+    }
+
+    /** Parse a JSON-array-of-objects TEXT column into a mutable list; defensive about null/blank/malformed. */
+    private List<Map<String, Object>> parseObjectArray(String json) {
         if (json == null || json.isBlank()) return new ArrayList<>();
         try {
             List<Map<String, Object>> parsed = objectMapper.readValue(json, new TypeReference<>() {});
@@ -319,7 +393,7 @@ public class LevelUpService {
         }
     }
 
-    private String writeFeatures(List<Map<String, Object>> features) {
+    private String writeObjectArray(List<Map<String, Object>> features) {
         try {
             return objectMapper.writeValueAsString(features);
         } catch (JsonProcessingException e) {

--- a/src/main/java/com/moo/charactermanagerservice/services/PCService.java
+++ b/src/main/java/com/moo/charactermanagerservice/services/PCService.java
@@ -76,7 +76,8 @@ public class PCService {
         String subclass = request == null ? null : request.subclass();
         Map<String, Integer> abilityIncreases = request == null ? null : request.abilityIncreases();
         String feat = request == null ? null : request.feat();
-        levelUpService.applyLevelUp(pc, subclass, abilityIncreases, feat);
+        List<Map<String, Object>> newSpells = request == null ? null : request.newSpells();
+        levelUpService.applyLevelUp(pc, subclass, abilityIncreases, feat, newSpells);
         return pcRepository.save(pc);
     }
 

--- a/src/test/java/com/moo/charactermanagerservice/controllers/PCControllerTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/controllers/PCControllerTest.java
@@ -173,7 +173,7 @@ class PCControllerTest {
 
     @Test
     void previewLevelUp_returns200_withPreview() {
-        LevelUpPreview preview = new LevelUpPreview(4, 5, 10, 3, 9, 39, 2, 3, Map.of(), Map.of(), false, List.of(), false, List.of(), List.of(), 0, 0);
+        LevelUpPreview preview = new LevelUpPreview(4, 5, 10, 3, 9, 39, 2, 3, Map.of(), Map.of(), false, List.of(), false, List.of(), List.of(), 0, 0, 0, 0);
         when(pcService.previewLevelUp(1L, ownerId)).thenReturn(preview);
 
         ResponseEntity<LevelUpPreview> response = pcController.previewLevelUp(1L, auth);
@@ -206,7 +206,7 @@ class PCControllerTest {
 
     @Test
     void levelUp_passesChoicesFromBody() {
-        LevelUpRequest body = new LevelUpRequest("Life Domain", java.util.Map.of("STR", 2), null);
+        LevelUpRequest body = new LevelUpRequest("Life Domain", java.util.Map.of("STR", 2), null, null);
         when(pcService.levelUpPC(1L, ownerId, body)).thenReturn(pc);
 
         pcController.levelUp(1L, auth, body);

--- a/src/test/java/com/moo/charactermanagerservice/services/LevelUpServiceTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/services/LevelUpServiceTest.java
@@ -7,7 +7,9 @@ import com.moo.charactermanagerservice.models.PC;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -491,5 +493,76 @@ class LevelUpServiceTest {
         LevelUpPreview p = service.preview(pc("Fighter", 1, 14, 12, 12));
         assertThat(p.currentCantripsKnown()).isEqualTo(0);
         assertThat(p.newCantripsKnown()).isEqualTo(0);
+    }
+
+    // --- Spell selection (learning new spells/cantrips) ---
+
+    private static Map<String, Object> spell(int lvl, String name) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("lvl", lvl);
+        m.put("name", name);
+        return m;
+    }
+
+    @Test
+    void preview_spellsKnown_progression() {
+        // Bard prepared spells: level 4 -> 7, level 5 -> 9.
+        LevelUpPreview p = service.preview(pc("Bard", 4, 14, 30, 30));
+        assertThat(p.currentSpellsKnown()).isEqualTo(7);
+        assertThat(p.newSpellsKnown()).isEqualTo(9);
+    }
+
+    @Test
+    void applyLevelUp_appendsNewSpells_withinDelta() {
+        // Bard 4 -> 5 (not an ASI level): prepared delta 7 -> 9 = 2 spells allowed, 0 cantrips.
+        PC bard = pc("Bard", 4, 14, 30, 30);
+
+        service.applyLevelUp(bard, null, null, null, List.of(spell(1, "Hold Person"), spell(2, "Invisibility")));
+
+        assertThat(bard.getSpells()).contains("Hold Person").contains("Invisibility");
+    }
+
+    @Test
+    void applyLevelUp_appendsCantrip_atCantripBreakpoint() {
+        // Bard 9 -> 10 (not an ASI level): cantrips 3 -> 4 = 1 cantrip allowed.
+        PC bard = pc("Bard", 9, 14, 60, 60);
+
+        service.applyLevelUp(bard, null, null, null, List.of(spell(0, "Light")));
+
+        assertThat(bard.getSpells()).contains("Light");
+    }
+
+    @Test
+    void applyLevelUp_rejectsTooManySpells() {
+        PC bard = pc("Bard", 4, 14, 30, 30); // 2 spells allowed
+        assertThatThrownBy(() -> service.applyLevelUp(bard, null, null, null,
+                List.of(spell(1, "A"), spell(1, "B"), spell(1, "C"))))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(400));
+    }
+
+    @Test
+    void applyLevelUp_rejectsCantripWhenNoneAllowed() {
+        PC bard = pc("Bard", 4, 14, 30, 30); // cantrip delta 0 at level 5
+        assertThatThrownBy(() -> service.applyLevelUp(bard, null, null, null, List.of(spell(0, "Light"))))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(400));
+    }
+
+    @Test
+    void applyLevelUp_rejectsDuplicateSpell() {
+        PC bard = pc("Bard", 4, 14, 30, 30);
+        bard.setSpells("[{\"lvl\":1,\"name\":\"Hold Person\"}]");
+        assertThatThrownBy(() -> service.applyLevelUp(bard, null, null, null, List.of(spell(1, "Hold Person"))))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(400));
+    }
+
+    @Test
+    void applyLevelUp_rejectsSpellsForNonCaster() {
+        PC fighter = pc("Fighter", 1, 14, 12, 12); // -> 2, no spell allowance
+        assertThatThrownBy(() -> service.applyLevelUp(fighter, null, null, null, List.of(spell(1, "Shield"))))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(400));
     }
 }

--- a/src/test/java/com/moo/charactermanagerservice/services/PCServiceTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/services/PCServiceTest.java
@@ -147,7 +147,7 @@ class PCServiceTest {
         PC result = pcService.levelUpPC(1L, ownerId, null);
 
         assertThat(result).isSameAs(pc);
-        verify(levelUpService).applyLevelUp(pc, null, null, null);
+        verify(levelUpService).applyLevelUp(pc, null, null, null, null);
         verify(pcRepository).save(pc);
     }
 
@@ -156,9 +156,10 @@ class PCServiceTest {
         when(pcRepository.findById(1L)).thenReturn(Optional.of(pc));
         when(pcRepository.save(pc)).thenReturn(pc);
 
-        pcService.levelUpPC(1L, ownerId, new LevelUpRequest("Life Domain", Map.of("STR", 2), "Sentinel"));
+        List<Map<String, Object>> spells = List.of(Map.of("lvl", 0, "name", "Light"));
+        pcService.levelUpPC(1L, ownerId, new LevelUpRequest("Life Domain", Map.of("STR", 2), "Sentinel", spells));
 
-        verify(levelUpService).applyLevelUp(pc, "Life Domain", Map.of("STR", 2), "Sentinel");
+        verify(levelUpService).applyLevelUp(pc, "Life Domain", Map.of("STR", 2), "Sentinel", spells);
     }
 
     @Test
@@ -170,7 +171,7 @@ class PCServiceTest {
                 .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value())
                         .isEqualTo(403));
 
-        verify(levelUpService, never()).applyLevelUp(any(), any(), any(), any());
+        verify(levelUpService, never()).applyLevelUp(any(), any(), any(), any(), any());
         verify(pcRepository, never()).save(any());
     }
 
@@ -178,7 +179,7 @@ class PCServiceTest {
 
     @Test
     void previewLevelUp_returnsPreview_whenOwner() {
-        LevelUpPreview preview = new LevelUpPreview(4, 5, 8, 2, 7, 39, 2, 3, Map.of(), Map.of(), false, List.of(), false, List.of(), List.of(), 0, 0);
+        LevelUpPreview preview = new LevelUpPreview(4, 5, 8, 2, 7, 39, 2, 3, Map.of(), Map.of(), false, List.of(), false, List.of(), List.of(), 0, 0, 0, 0);
         when(pcRepository.findById(1L)).thenReturn(Optional.of(pc));
         when(levelUpService.preview(pc)).thenReturn(preview);
 


### PR DESCRIPTION
Adds spell selection to the level-up flow. ClassProgression.preparedSpellsFor provides the 2024 prepared/known-spell counts per caster class by level (full-caster table for bard/cleric/druid/sorcerer/wizard, pact table for warlock); cantripsKnownFor already existed. LevelUpPreview now surfaces current/new spell counts so the SPA can show the delta.

LevelUpRequest gains newSpells; LevelUpService.applySpellChoices appends them to the PC's spells JSON. Server-authoritative on COUNT only: new cantrips and new leveled spells may not exceed their respective level-up deltas, and duplicates (by name) are rejected — but individual spell NAMES are not validated, because the spell list lives in the frontend and the backend must not depend on the external D&D API (same trust posture as feats/subclasses; documented in code). The features parse/append helpers were generalized (parseObjectArray/ writeObjectArray) and reused for the spells column.

Tests: LevelUpServiceTest +7 (count progression, append spells/cantrip within delta, reject too many, reject cantrip when none allowed, reject duplicate, reject for non-caster) + controller/service plumbing. All logic tests green (the only failing test is the pre-existing DB-dependent context-load test).