### PR TITLE
feat: populate subclass catalog to activate the level-up picker

### DIFF
--- a/src/main/java/com/moo/charactermanagerservice/progression/ClassProgression.java
+++ b/src/main/java/com/moo/charactermanagerservice/progression/ClassProgression.java
@@ -212,11 +212,10 @@ public final class ClassProgression {
     // to match the app's existing creation flow; every other class is level 3 (2024 PHB).
     // Unmapped classes default to 3.
     //
-    // The CATALOG (valid subclass names per class) is intentionally EMPTY for now: this
-    // phase ships the selection *mechanism* (timing, preview signal, server validation,
-    // request plumbing) without authoring subclass content. The flow stays dormant — the
-    // preview reports no options and nothing is required — and activates automatically,
-    // with no code change, once a class is given catalog entries here.
+    // The CATALOG holds the valid subclass NAMES per class (server-authoritative). Names only;
+    // descriptions are presentation and live in the frontend. Sorcerer/Warlock pick at level 1
+    // during character creation, so their entries here are never reached by the level-up flow
+    // (kept for a complete, correct catalog); every other class activates the picker at level 3.
 
     private static final int DEFAULT_SUBCLASS_LEVEL = 3;
 
@@ -235,8 +234,34 @@ public final class ClassProgression {
             Map.entry("rogue", 3)
     );
 
-    /** Valid subclass names per class. Empty until content is authored (see note above). */
-    private static final Map<String, List<String>> SUBCLASS_CATALOG = Map.of();
+    /** Valid subclass names per class (2024 PHB). */
+    private static final Map<String, List<String>> SUBCLASS_CATALOG = Map.ofEntries(
+            Map.entry("barbarian", List.of(
+                    "Path of the Berserker", "Path of the Wild Heart", "Path of the World Tree", "Path of the Zealot")),
+            Map.entry("bard", List.of(
+                    "College of Dance", "College of Glamour", "College of Lore", "College of Valor")),
+            Map.entry("cleric", List.of(
+                    "Life Domain", "Light Domain", "Trickery Domain", "War Domain")),
+            Map.entry("druid", List.of(
+                    "Circle of the Land", "Circle of the Moon", "Circle of the Sea", "Circle of the Stars")),
+            Map.entry("fighter", List.of(
+                    "Battle Master", "Champion", "Eldritch Knight", "Psi Warrior")),
+            Map.entry("monk", List.of(
+                    "Warrior of Mercy", "Warrior of Shadow", "Warrior of the Elements", "Warrior of the Open Hand")),
+            Map.entry("paladin", List.of(
+                    "Oath of Devotion", "Oath of Glory", "Oath of the Ancients", "Oath of Vengeance")),
+            Map.entry("ranger", List.of(
+                    "Beast Master", "Fey Wanderer", "Gloom Stalker", "Hunter")),
+            Map.entry("rogue", List.of(
+                    "Arcane Trickster", "Assassin", "Soulknife", "Thief")),
+            Map.entry("wizard", List.of(
+                    "Abjurer", "Diviner", "Evoker", "Illusionist")),
+            // Sorcerer/Warlock choose at level 1 (creation); listed for catalog completeness.
+            Map.entry("sorcerer", List.of(
+                    "Aberrant Sorcery", "Clockwork Sorcery", "Draconic Sorcery", "Wild Magic Sorcery")),
+            Map.entry("warlock", List.of(
+                    "Archfey Patron", "Celestial Patron", "Fiend Patron", "Great Old One Patron"))
+    );
 
     /** The character level at which the given class selects its subclass. */
     public static int subclassLevelFor(String clazz) {

--- a/src/test/java/com/moo/charactermanagerservice/services/LevelUpServiceTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/services/LevelUpServiceTest.java
@@ -214,6 +214,7 @@ class LevelUpServiceTest {
     @Test
     void applyLevelUp_caster_survivesMalformedSlotJson() {
         PC wizard = pc("Wizard", 2, 14, 14, 14);
+        wizard.setSubclass("Evoker"); // already has a subclass, so none is due at level 3
         wizard.setSpellSlots("not-valid-json");
 
         service.applyLevelUp(wizard);
@@ -225,11 +226,11 @@ class LevelUpServiceTest {
     // --- subclass selection mechanism (Phase 3 — catalog intentionally empty) ---
 
     @Test
-    void preview_subclassDue_atGrantLevelWithNoSubclass() {
+    void preview_subclassDue_atGrantLevelWithOptions() {
         // Cleric grant level is 3; leveling 2 -> 3 with no subclass yet.
         LevelUpPreview p = service.preview(pc("Cleric", 2, 14, 14, 14));
         assertThat(p.subclassDue()).isTrue();
-        assertThat(p.subclassOptions()).isEmpty(); // no catalog content yet
+        assertThat(p.subclassOptions()).contains("Life Domain", "War Domain");
     }
 
     @Test
@@ -247,7 +248,6 @@ class LevelUpServiceTest {
 
     @Test
     void applyLevelUp_setsChosenSubclass_whenDue() {
-        // Catalog empty -> server can't validate membership, so any non-blank choice is accepted.
         PC cleric = pc("Cleric", 2, 14, 14, 14);
 
         service.applyLevelUp(cleric, "Life Domain");
@@ -265,14 +265,20 @@ class LevelUpServiceTest {
     }
 
     @Test
-    void applyLevelUp_dueButNoChoiceAndEmptyCatalog_proceedsWithoutSubclass() {
-        // With no catalog content the flow is dormant: a level-up still succeeds with no subclass.
+    void applyLevelUp_requiresSubclassChoice_whenDue() {
+        // Catalog now has options, so a subclass must be selected at the grant level.
         PC cleric = pc("Cleric", 2, 14, 14, 14);
+        assertThatThrownBy(() -> service.applyLevelUp(cleric, null))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(400));
+    }
 
-        service.applyLevelUp(cleric, null);
-
-        assertThat(cleric.getLevel()).isEqualTo((short) 3);
-        assertThat(cleric.getSubclass()).isNull();
+    @Test
+    void applyLevelUp_rejectsUnknownSubclass() {
+        PC cleric = pc("Cleric", 2, 14, 14, 14);
+        assertThatThrownBy(() -> service.applyLevelUp(cleric, "Bogus Domain"))
+                .isInstanceOf(ResponseStatusException.class)
+                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(400));
     }
 
     @Test


### PR DESCRIPTION
The subclass-selection mechanism shipped earlier but was dormant because the server catalog was empty. SUBCLASS_CATALOG is now filled with the 2024 PHB subclass names for all classes, so the picker activates: non-sorcerer/warlock characters reaching level 3 without a subclass are now offered (and required to pick) one, validated against the catalog. Sorcerer/Warlock keep choosing at level 1 during creation (listed for catalog completeness; never reached on level-up).

Tests: updated the Phase 3 subclass tests that assumed an empty catalog (preview now lists options; a choice is required at the grant level; an unknown subclass is rejected) and added a reject-unknown case. One slot-parsing test was given a pre-set subclass so it stays focused. LevelUpServiceTest green (58).