### PR TITLE
feat: add rolled-HP option to level-up

### DIFF
--- a/src/main/java/com/moo/charactermanagerservice/dto/HpMode.java
+++ b/src/main/java/com/moo/charactermanagerservice/dto/HpMode.java
@@ -1,0 +1,14 @@
+package com.moo.charactermanagerservice.dto;
+
+/**
+ * How a level-up's hit-point gain is determined.
+ *
+ * <p>{@link #AVERAGE} (the default) takes the fixed hit-die average — the existing behaviour, so a
+ * request that omits the mode is unchanged. {@link #ROLL} rolls the hit die instead. In ROLL mode
+ * the <strong>server</strong> performs the roll; a client-supplied result is never trusted, so the
+ * client cannot inflate its HP. Both modes add the CON modifier and floor the per-level gain at 1.
+ */
+public enum HpMode {
+    AVERAGE,
+    ROLL
+}

--- a/src/main/java/com/moo/charactermanagerservice/dto/LevelUpRequest.java
+++ b/src/main/java/com/moo/charactermanagerservice/dto/LevelUpRequest.java
@@ -18,10 +18,22 @@ import java.util.Map;
  * the <em>count</em> against the level-up delta (and rejects duplicates); it does not validate
  * individual spell names, because the spell list lives in the frontend (the backend must not
  * depend on the external D&D API). Same trust posture as feats/subclasses.
+ *
+ * <p>HP: {@code hpMode} — whether this level's hit points use the fixed average or a roll. It is
+ * optional; {@code null} (or an omitted field) means {@link HpMode#AVERAGE}, so existing clients are
+ * unaffected. In {@link HpMode#ROLL} the server rolls the die — the client never sends a roll
+ * result, only the choice of mode.
  */
 public record LevelUpRequest(
         String subclass,
         Map<String, Integer> abilityIncreases,
         String feat,
-        List<Map<String, Object>> newSpells
-) {}
+        List<Map<String, Object>> newSpells,
+        HpMode hpMode
+) {
+    /** Back-compat constructor for callers that don't choose an HP mode: defaults to AVERAGE. */
+    public LevelUpRequest(String subclass, Map<String, Integer> abilityIncreases,
+                          String feat, List<Map<String, Object>> newSpells) {
+        this(subclass, abilityIncreases, feat, newSpells, HpMode.AVERAGE);
+    }
+}

--- a/src/main/java/com/moo/charactermanagerservice/services/LevelUpService.java
+++ b/src/main/java/com/moo/charactermanagerservice/services/LevelUpService.java
@@ -4,11 +4,13 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moo.charactermanagerservice.dto.FeatureGain;
+import com.moo.charactermanagerservice.dto.HpMode;
 import com.moo.charactermanagerservice.dto.LevelUpPreview;
 import com.moo.charactermanagerservice.models.PC;
 import com.moo.charactermanagerservice.progression.ClassFeatures;
 import com.moo.charactermanagerservice.progression.ClassProgression;
 import com.moo.charactermanagerservice.progression.FeatCatalog;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -17,7 +19,9 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.TreeMap;
+import java.util.random.RandomGenerator;
 
 /**
  * Server-authoritative level-up rules engine (single-class, D&D 5e 2024).
@@ -27,8 +31,13 @@ import java.util.TreeMap;
  * here. Keeping the rules out of the controller and out of PCService means the math is unit
  * tested in isolation (no repo, no Spring context, no security).
  *
- * <p><strong>HP policy (Phase 1):</strong> fixed average — {@code averageHitDieValue + CON mod},
- * floored at {@value #MIN_HP_PER_LEVEL} per level (5e minimum). Rolled HP is a future seam.
+ * <p><strong>HP policy:</strong> per request, either the fixed average or a roll
+ * ({@link HpMode}) — {@code (averageHitDieValue | d(hitDie)) + CON mod}, floored at
+ * {@value #MIN_HP_PER_LEVEL} per level (5e minimum). The mode defaults to {@link HpMode#AVERAGE}
+ * so behaviour is unchanged when none is sent. In {@link HpMode#ROLL} the die is rolled
+ * <em>here, on the server</em> ({@link #rng}) at commit time; the client never supplies a roll
+ * result, so it cannot inflate its HP. Because a roll isn't known until commit, the
+ * {@link #preview(PC) preview} always reports the average (the floor/best-case estimate).
  *
  * <p><strong>Spell slots (Phase 2):</strong> for caster classes, the {@code spellSlots} JSON-as-TEXT
  * column is rebuilt from {@link ClassProgression#spellSlotsFor} — {@code max} is set from the table
@@ -48,9 +57,18 @@ public class LevelUpService {
     private static final int MIN_HP_PER_LEVEL = 1;
 
     private final ObjectMapper objectMapper;
+    /** Source of randomness for rolled HP. Seedable via the test constructor for determinism. */
+    private final RandomGenerator rng;
 
+    @Autowired
     public LevelUpService(ObjectMapper objectMapper) {
+        this(objectMapper, new Random());
+    }
+
+    /** Test seam: inject a seeded/fixed RNG so rolled-HP outcomes are deterministic. */
+    LevelUpService(ObjectMapper objectMapper, RandomGenerator rng) {
         this.objectMapper = objectMapper;
+        this.rng = rng;
     }
 
     /** Compute — without persisting — what advancing one level would grant. */
@@ -108,6 +126,12 @@ public class LevelUpService {
         return applyLevelUp(pc, chosenSubclass, abilityIncreases, chosenFeat, null);
     }
 
+    /** Convenience overload defaulting to {@link HpMode#AVERAGE} (existing behaviour). */
+    public PC applyLevelUp(PC pc, String chosenSubclass, Map<String, Integer> abilityIncreases,
+                           String chosenFeat, List<Map<String, Object>> newSpells) {
+        return applyLevelUp(pc, chosenSubclass, abilityIncreases, chosenFeat, newSpells, HpMode.AVERAGE);
+    }
+
     /**
      * Mutate the given (managed) PC in place to its next level: validate and apply the player's
      * choices (subclass; at an ASI level exactly one of an Ability Score Improvement or a feat;
@@ -122,9 +146,12 @@ public class LevelUpService {
      * @param abilityIncreases the ASI allocation ({@code ABILITY -> points}), or {@code null}
      * @param chosenFeat       the chosen General feat (the ASI alternative), or {@code null}
      * @param newSpells        cantrips/spells learned this level (count-validated), or {@code null}
+     * @param hpMode           average vs. rolled HP for this level; {@code null} means
+     *                         {@link HpMode#AVERAGE}. In ROLL mode the server rolls the die — the
+     *                         client supplies only the mode, never a roll result.
      */
     public PC applyLevelUp(PC pc, String chosenSubclass, Map<String, Integer> abilityIncreases,
-                           String chosenFeat, List<Map<String, Object>> newSpells) {
+                           String chosenFeat, List<Map<String, Object>> newSpells, HpMode hpMode) {
         int currentLevel = currentLevel(pc);
         assertCanLevelUp(currentLevel);
         int newLevel = currentLevel + 1;
@@ -139,7 +166,7 @@ public class LevelUpService {
 
         int newConMod = ClassProgression.abilityModifier(nz(pc.getAbilityCon()));
         int hitDie = ClassProgression.hitDie(pc.getClazz());
-        int hpGained = hpGain(hitDie, newConMod);
+        int hpGained = hpGain(hitDie, newConMod, hpMode);
         // A rise in CON's modifier grants HP to every level you already have (this level's gain
         // above already reflects the new modifier, so only the prior levels are added here).
         int retroactiveHp = (newLevel - 1) * (newConMod - oldConMod);
@@ -155,8 +182,26 @@ public class LevelUpService {
         return pc;
     }
 
+    /** Average-mode HP gain — used by the preview (a roll isn't known until commit). */
     private int hpGain(int hitDie, int conMod) {
-        return Math.max(MIN_HP_PER_LEVEL, ClassProgression.averageHitDieValue(hitDie) + conMod);
+        return hpGain(hitDie, conMod, HpMode.AVERAGE);
+    }
+
+    /**
+     * Per-level HP gain for the chosen mode: the hit-die value (fixed average, or a server-side
+     * roll in {@link HpMode#ROLL}) plus the CON modifier, floored at {@value #MIN_HP_PER_LEVEL}.
+     * A {@code null} mode is treated as {@link HpMode#AVERAGE}.
+     */
+    private int hpGain(int hitDie, int conMod, HpMode mode) {
+        int dieValue = (mode == HpMode.ROLL)
+                ? rollHitDie(hitDie)
+                : ClassProgression.averageHitDieValue(hitDie);
+        return Math.max(MIN_HP_PER_LEVEL, dieValue + conMod);
+    }
+
+    /** Roll a single hit die on the server: a uniform result in {@code [1, hitDie]}. */
+    private int rollHitDie(int hitDie) {
+        return rng.nextInt(hitDie) + 1;
     }
 
     private int currentLevel(PC pc) {

--- a/src/main/java/com/moo/charactermanagerservice/services/PCService.java
+++ b/src/main/java/com/moo/charactermanagerservice/services/PCService.java
@@ -1,5 +1,6 @@
 package com.moo.charactermanagerservice.services;
 
+import com.moo.charactermanagerservice.dto.HpMode;
 import com.moo.charactermanagerservice.dto.LevelUpPreview;
 import com.moo.charactermanagerservice.dto.LevelUpRequest;
 import com.moo.charactermanagerservice.exceptions.PCNotFoundException;
@@ -77,7 +78,8 @@ public class PCService {
         Map<String, Integer> abilityIncreases = request == null ? null : request.abilityIncreases();
         String feat = request == null ? null : request.feat();
         List<Map<String, Object>> newSpells = request == null ? null : request.newSpells();
-        levelUpService.applyLevelUp(pc, subclass, abilityIncreases, feat, newSpells);
+        HpMode hpMode = request == null || request.hpMode() == null ? HpMode.AVERAGE : request.hpMode();
+        levelUpService.applyLevelUp(pc, subclass, abilityIncreases, feat, newSpells, hpMode);
         return pcRepository.save(pc);
     }
 

--- a/src/test/java/com/moo/charactermanagerservice/services/LevelUpServiceTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/services/LevelUpServiceTest.java
@@ -2,6 +2,7 @@ package com.moo.charactermanagerservice.services;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.moo.charactermanagerservice.dto.FeatureGain;
+import com.moo.charactermanagerservice.dto.HpMode;
 import com.moo.charactermanagerservice.dto.LevelUpPreview;
 import com.moo.charactermanagerservice.models.PC;
 import org.junit.jupiter.api.Test;
@@ -10,6 +11,8 @@ import org.springframework.web.server.ResponseStatusException;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
+import java.util.random.RandomGenerator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -570,5 +573,93 @@ class LevelUpServiceTest {
         assertThatThrownBy(() -> service.applyLevelUp(fighter, null, null, null, List.of(spell(1, "Shield"))))
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value()).isEqualTo(400));
+    }
+
+    // --- Rolled HP (HpMode.ROLL) ---
+
+    /** A service whose hit-die roll always returns {@code roll} (so HP outcomes are deterministic). */
+    private static LevelUpService serviceRolling(int roll) {
+        RandomGenerator fixed = new Random() {
+            @Override
+            public int nextInt(int bound) {
+                return roll - 1; // rollHitDie() adds 1, yielding exactly `roll`
+            }
+        };
+        return new LevelUpService(new ObjectMapper(), fixed);
+    }
+
+    @Test
+    void applyLevelUp_roll_usesServerRoll_notAverage() {
+        // Fighter 4 -> 5, d10, CON 16 (+3); forced max roll 10 -> 13 HP (avg path would be 9).
+        PC fighter = pc("Fighter", 4, 16, 30, 22);
+        serviceRolling(10).applyLevelUp(fighter, null, null, null, null, HpMode.ROLL);
+
+        assertThat(fighter.getLevel()).isEqualTo((short) 5);
+        assertThat(fighter.getHpMax()).isEqualTo((short) 43);     // 30 + 13
+        assertThat(fighter.getHpCurrent()).isEqualTo((short) 35); // 22 + 13
+    }
+
+    @Test
+    void applyLevelUp_roll_minRoll_addsConMod() {
+        // Fighter 4 -> 5, d10, CON 16 (+3); forced min roll 1 -> 1 + 3 = 4 HP.
+        PC fighter = pc("Fighter", 4, 16, 30, 30);
+        serviceRolling(1).applyLevelUp(fighter, null, null, null, null, HpMode.ROLL);
+        assertThat(fighter.getHpMax()).isEqualTo((short) 34);
+    }
+
+    @Test
+    void applyLevelUp_roll_flooredAtOne_withHeavyConPenalty() {
+        // Sorcerer d6, CON 3 (-4); even a min roll of 1 -> 1 - 4 = -3, floored to 1.
+        PC sorcerer = pc("Sorcerer", 1, 3, 4, 4);
+        serviceRolling(1).applyLevelUp(sorcerer, null, null, null, null, HpMode.ROLL);
+        assertThat(sorcerer.getHpMax()).isEqualTo((short) 5); // 4 + 1
+    }
+
+    @Test
+    void applyLevelUp_roll_alwaysWithinHitDieRange_overManyRolls() {
+        // Real RNG: every rolled gain must land in [max(1, 1+conMod), max(1, hitDie+conMod)].
+        LevelUpService rolling = new LevelUpService(new ObjectMapper(), new Random(42));
+        int hitDie = 10, conMod = 3; // Fighter, CON 16
+        int min = Math.max(1, 1 + conMod);
+        int max = Math.max(1, hitDie + conMod);
+        for (int i = 0; i < 500; i++) {
+            PC fighter = pc("Fighter", 4, 16, 30, 30);
+            rolling.applyLevelUp(fighter, null, null, null, null, HpMode.ROLL);
+            int gained = fighter.getHpMax() - 30;
+            assertThat(gained).isBetween(min, max);
+        }
+    }
+
+    @Test
+    void applyLevelUp_roll_conIncrease_stillGrantsRetroactiveHp() {
+        // Fighter 3 -> 4 with ASI CON 15 (+2) -> 17 (+3); forced max roll 10.
+        // This level: rolled 10 + new CON mod 3 = 13; retroactive (4-1) * (3-2) = 3; total +16.
+        PC fighter = pc("Fighter", 3, 15, 28, 28);
+        serviceRolling(10).applyLevelUp(fighter, null, Map.of("CON", 2), null, null, HpMode.ROLL);
+
+        assertThat(fighter.getAbilityCon()).isEqualTo((short) 17);
+        assertThat(fighter.getHpMax()).isEqualTo((short) 44); // 28 + 13 + 3
+        assertThat(fighter.getHpCurrent()).isEqualTo((short) 44);
+    }
+
+    @Test
+    void applyLevelUp_averageMode_matchesDefault_unchanged() {
+        // Explicit AVERAGE must equal the legacy default path (d10 avg 6 + CON 3 = 9), and the
+        // (forced-max-roll) RNG must be ignored entirely in AVERAGE mode.
+        PC viaDefault = pc("Fighter", 4, 16, 30, 22);
+        service.applyLevelUp(viaDefault); // legacy default
+
+        PC viaExplicit = pc("Fighter", 4, 16, 30, 22);
+        serviceRolling(10).applyLevelUp(viaExplicit, null, null, null, null, HpMode.AVERAGE);
+
+        assertThat(viaExplicit.getHpMax()).isEqualTo(viaDefault.getHpMax());   // 39
+        assertThat(viaExplicit.getHpCurrent()).isEqualTo(viaDefault.getHpCurrent());
+    }
+
+    @Test
+    void preview_alwaysAverage_evenWhenServerWouldRollHigh() {
+        // Preview takes no mode: it always reports the average, regardless of the RNG.
+        LevelUpPreview p = serviceRolling(10).preview(pc("Fighter", 4, 16, 30, 30));
+        assertThat(p.hpGained()).isEqualTo(9); // d10 avg 6 + CON 3, not the forced roll of 13
     }
 }

--- a/src/test/java/com/moo/charactermanagerservice/services/PCServiceTest.java
+++ b/src/test/java/com/moo/charactermanagerservice/services/PCServiceTest.java
@@ -1,5 +1,6 @@
 package com.moo.charactermanagerservice.services;
 
+import com.moo.charactermanagerservice.dto.HpMode;
 import com.moo.charactermanagerservice.dto.LevelUpPreview;
 import com.moo.charactermanagerservice.dto.LevelUpRequest;
 import com.moo.charactermanagerservice.exceptions.PCNotFoundException;
@@ -147,7 +148,7 @@ class PCServiceTest {
         PC result = pcService.levelUpPC(1L, ownerId, null);
 
         assertThat(result).isSameAs(pc);
-        verify(levelUpService).applyLevelUp(pc, null, null, null, null);
+        verify(levelUpService).applyLevelUp(pc, null, null, null, null, HpMode.AVERAGE);
         verify(pcRepository).save(pc);
     }
 
@@ -159,7 +160,28 @@ class PCServiceTest {
         List<Map<String, Object>> spells = List.of(Map.of("lvl", 0, "name", "Light"));
         pcService.levelUpPC(1L, ownerId, new LevelUpRequest("Life Domain", Map.of("STR", 2), "Sentinel", spells));
 
-        verify(levelUpService).applyLevelUp(pc, "Life Domain", Map.of("STR", 2), "Sentinel", spells);
+        verify(levelUpService).applyLevelUp(pc, "Life Domain", Map.of("STR", 2), "Sentinel", spells, HpMode.AVERAGE);
+    }
+
+    @Test
+    void levelUpPC_forwardsRollHpMode() {
+        when(pcRepository.findById(1L)).thenReturn(Optional.of(pc));
+        when(pcRepository.save(pc)).thenReturn(pc);
+
+        pcService.levelUpPC(1L, ownerId, new LevelUpRequest(null, null, null, null, HpMode.ROLL));
+
+        verify(levelUpService).applyLevelUp(pc, null, null, null, null, HpMode.ROLL);
+    }
+
+    @Test
+    void levelUpPC_nullHpMode_defaultsToAverage() {
+        when(pcRepository.findById(1L)).thenReturn(Optional.of(pc));
+        when(pcRepository.save(pc)).thenReturn(pc);
+
+        // hpMode explicitly null in the request -> service coalesces to AVERAGE.
+        pcService.levelUpPC(1L, ownerId, new LevelUpRequest(null, null, null, null, null));
+
+        verify(levelUpService).applyLevelUp(pc, null, null, null, null, HpMode.AVERAGE);
     }
 
     @Test


### PR DESCRIPTION
Add an optional HpMode (AVERAGE | ROLL) to the level-up flow. In ROLL mode the server rolls the hit die (never trusting a client-supplied result), adds the CON modifier, and floors the gain at 1 per level. AVERAGE remains the default so existing clients are unchanged.

The roll happens at commit time, so the preview keeps reporting the average (documented). Retroactive HP on a CON increase is unaffected.